### PR TITLE
Latrafficdataset

### DIFF
--- a/test/dataset_test.py
+++ b/test/dataset_test.py
@@ -1,6 +1,6 @@
 import numpy as np
 import networkx as nx
-from torch_geometric_temporal.data.dataset import ChickenpoxDatasetLoader, METRLADatasetLoader
+from torch_geometric_temporal.data.dataset import ChickenpoxDatasetLoader, METRLADatasetLoader, PemsBayDatasetLoader
 from torch_geometric_temporal.data.discrete.static_graph_discrete_signal import StaticGraphDiscreteSignal
 from torch_geometric_temporal.data.discrete.dynamic_graph_discrete_signal import DynamicGraphDiscreteSignal
 from torch_geometric_temporal.data.splitter import discrete_train_test_split
@@ -82,24 +82,44 @@ def test_chickenpox():
             assert snapshot.y.shape == (20, )
 
 def test_metrla():
-    loader = ChickenpoxDatasetLoader()
+    loader = METRLADatasetLoader()
     dataset = loader.get_dataset()
     for epoch in range(3):
         for snapshot in dataset:
             assert snapshot.edge_index.shape == (2, 1722)
-            assert snapshot.edge_attr.shape == (1772, )
+            assert snapshot.edge_attr.shape == (1722, )
             assert snapshot.x.shape == (207, 2, 12)
             assert snapshot.y.shape == (207, 12)
 
 def test_metrla_task_generator():
-    loader = ChickenpoxDatasetLoader()
+    loader = METRLADatasetLoader()
     dataset = loader.get_dataset(num_timesteps_in=6, num_timesteps_out=5)
     for epoch in range(3):
         for snapshot in dataset:
             assert snapshot.edge_index.shape == (2, 1722)
-            assert snapshot.edge_attr.shape == (1772, )
+            assert snapshot.edge_attr.shape == (1722, )
             assert snapshot.x.shape == (207, 2, 6)
             assert snapshot.y.shape == (207, 5)
+
+def test_pemsbay():
+    loader = PemsBayDatasetLoader()
+    dataset = loader.get_dataset()
+    for epoch in range(3):
+        for snapshot in dataset:
+            assert snapshot.edge_index.shape == (2, 2694)
+            assert snapshot.edge_attr.shape == (2694, )
+            assert snapshot.x.shape == (325, 2, 12)
+            assert snapshot.y.shape == (325, 2, 12)
+
+def test_pemsbay_task_generator():
+    loader = PemsBayDatasetLoader()
+    dataset = loader.get_dataset(num_timesteps_in=6, num_timesteps_out=5)
+    for epoch in range(3):
+        for snapshot in dataset:
+            assert snapshot.edge_index.shape == (2, 2694)
+            assert snapshot.edge_attr.shape == (2694, )
+            assert snapshot.x.shape == (325, 2, 6)
+            assert snapshot.y.shape == (325, 2, 5)
 
 def test_discrete_train_test_split_static():
     loader = ChickenpoxDatasetLoader()

--- a/test/dataset_test.py
+++ b/test/dataset_test.py
@@ -82,7 +82,7 @@ def test_chickenpox():
             assert snapshot.y.shape == (20, )
 
 def test_metrla():
-    loader = METRLADatasetLoader()
+    loader = METRLADatasetLoader(raw_data_dir="/tmp/")
     dataset = loader.get_dataset()
     for epoch in range(3):
         for snapshot in dataset:
@@ -92,7 +92,7 @@ def test_metrla():
             assert snapshot.y.shape == (207, 12)
 
 def test_metrla_task_generator():
-    loader = METRLADatasetLoader()
+    loader = METRLADatasetLoader(raw_data_dir="/tmp/")
     dataset = loader.get_dataset(num_timesteps_in=6, num_timesteps_out=5)
     for epoch in range(3):
         for snapshot in dataset:
@@ -102,7 +102,7 @@ def test_metrla_task_generator():
             assert snapshot.y.shape == (207, 5)
 
 def test_pemsbay():
-    loader = PemsBayDatasetLoader()
+    loader = PemsBayDatasetLoader(raw_data_dir="/tmp/")
     dataset = loader.get_dataset()
     for epoch in range(3):
         for snapshot in dataset:
@@ -112,7 +112,7 @@ def test_pemsbay():
             assert snapshot.y.shape == (325, 2, 12)
 
 def test_pemsbay_task_generator():
-    loader = PemsBayDatasetLoader()
+    loader = PemsBayDatasetLoader(raw_data_dir="/tmp/")
     dataset = loader.get_dataset(num_timesteps_in=6, num_timesteps_out=5)
     for epoch in range(3):
         for snapshot in dataset:

--- a/test/dataset_test.py
+++ b/test/dataset_test.py
@@ -1,6 +1,6 @@
 import numpy as np
 import networkx as nx
-from torch_geometric_temporal.data.dataset import ChickenpoxDatasetLoader
+from torch_geometric_temporal.data.dataset import ChickenpoxDatasetLoader, METRLADatasetLoader
 from torch_geometric_temporal.data.discrete.static_graph_discrete_signal import StaticGraphDiscreteSignal
 from torch_geometric_temporal.data.discrete.dynamic_graph_discrete_signal import DynamicGraphDiscreteSignal
 from torch_geometric_temporal.data.splitter import discrete_train_test_split
@@ -81,6 +81,25 @@ def test_chickenpox():
             assert snapshot.x.shape == (20, 4)
             assert snapshot.y.shape == (20, )
 
+def test_metrla():
+    loader = ChickenpoxDatasetLoader()
+    dataset = loader.get_dataset()
+    for epoch in range(3):
+        for snapshot in dataset:
+            assert snapshot.edge_index.shape == (2, 1722)
+            assert snapshot.edge_attr.shape == (1772, )
+            assert snapshot.x.shape == (207, 2, 12)
+            assert snapshot.y.shape == (207, 12)
+
+def test_metrla_task_generator():
+    loader = ChickenpoxDatasetLoader()
+    dataset = loader.get_dataset(num_timesteps_in=6, num_timesteps_out=5)
+    for epoch in range(3):
+        for snapshot in dataset:
+            assert snapshot.edge_index.shape == (2, 1722)
+            assert snapshot.edge_attr.shape == (1772, )
+            assert snapshot.x.shape == (207, 2, 6)
+            assert snapshot.y.shape == (207, 5)
 
 def test_discrete_train_test_split_static():
     loader = ChickenpoxDatasetLoader()

--- a/torch_geometric_temporal/data/dataset/__init__.py
+++ b/torch_geometric_temporal/data/dataset/__init__.py
@@ -1,1 +1,2 @@
 from .chickenpox import ChickenpoxDatasetLoader
+from .metr_la import METRLADatasetLoader

--- a/torch_geometric_temporal/data/dataset/__init__.py
+++ b/torch_geometric_temporal/data/dataset/__init__.py
@@ -1,2 +1,3 @@
 from .chickenpox import ChickenpoxDatasetLoader
 from .metr_la import METRLADatasetLoader
+from .pems_bay import PemsBayDatasetLoader

--- a/torch_geometric_temporal/data/dataset/metr_la.py
+++ b/torch_geometric_temporal/data/dataset/metr_la.py
@@ -1,6 +1,7 @@
 import os
 import zipfile
 import numpy as np
+import torch
 from six.moves import urllib
 from torch_geometric_temporal.data.discrete.static_graph_discrete_signal import StaticGraphDiscreteSignal
 
@@ -37,8 +38,8 @@ class METRLADatasetLoader(object):
         stds = np.std(X, axis=(0, 2))
         X = X / stds.reshape(1, -1, 1)
         
-        self.A = A
-        self.X = X
+        self.A = torch.from_numpy(A)
+        self.X = torch.from_numpy(X)
 
     def _get_edges(self):
         pass

--- a/torch_geometric_temporal/data/dataset/metr_la.py
+++ b/torch_geometric_temporal/data/dataset/metr_la.py
@@ -1,0 +1,14 @@
+import numpy as np
+from torch_geometric_temporal.data.discrete.static_graph_discrete_signal import StaticGraphDiscreteSignal
+
+
+class METRLADatasetLoader(object):
+    """A traffic forecasting dataset based on Los Angeles
+    Metropolitan traffic conditions. The dataset contains traffic
+    readings collected from 207 loop detectors on highways in Los Angeles 
+    County in aggregated 5 minute intervals for 4 months between March 2012 
+    to June 2012.
+    """
+
+    def __init__(self, arg):
+        super(MetrlaDatasetLoader, self).__init__()

--- a/torch_geometric_temporal/data/dataset/metr_la.py
+++ b/torch_geometric_temporal/data/dataset/metr_la.py
@@ -50,17 +50,20 @@ class METRLADatasetLoader(object):
     def _get_edge_weights(self):
         self.edge_weights = np.ones(self.edges.shape[1])
 
-    def _get_features(self):
-        self.features = []
-        time_x = np.transpose(self.X, (2,0,1))
-        for time in range(len(time_x)):
-            self.features.append(time_x[time])
+    def _generate_task(self, num_timesteps_in: int=12, num_timesteps_out: int=12):
+        """Uses the node features of the graph and generates a feature/target
+        relationship of the shape
+        (num_nodes, num_node_features, num_timesteps_in) -> (num_nodes, num_timesteps_out)
+        predicting the average traffic speed using num_timesteps_in to predict the
+        traffic conditions in the next num_timesteps_out
 
-
-    def _get_targets(self):
+        Args:
+            num_timesteps_in (int): number of timesteps the sequence model sees
+            num_timesteps_out (int): number of timesteps the sequence model has to predict
+        """
         pass
 
-    def get_dataset(self) -> StaticGraphDiscreteSignal:
+    def get_dataset(self, num_timesteps_in: int=12, num_timesteps_out: int=12) -> StaticGraphDiscreteSignal:
         """Returns data iterator for METR-LA dataset as an instance of the
         static graph discrete signal class.
 
@@ -70,8 +73,7 @@ class METRLADatasetLoader(object):
         """
         self._get_edges()
         self._get_edge_weights()
-        self._get_features()
-        self._get_targets()
+        self._generate_task(num_timesteps_in, num_timesteps_out)
         dataset = StaticGraphDiscreteSignal(self.edges, self.edge_weights, self.features, self.targets)
 
         return dataset

--- a/torch_geometric_temporal/data/dataset/metr_la.py
+++ b/torch_geometric_temporal/data/dataset/metr_la.py
@@ -2,6 +2,7 @@ import os
 import zipfile
 import numpy as np
 import torch
+from torch_geometric.utils import dense_to_sparse
 from six.moves import urllib
 from torch_geometric_temporal.data.discrete.static_graph_discrete_signal import StaticGraphDiscreteSignal
 
@@ -42,13 +43,19 @@ class METRLADatasetLoader(object):
         self.X = torch.from_numpy(X)
 
     def _get_edges(self):
-        pass
+        edge_indices, values = dense_to_sparse(self.A)
+        edge_indices = edge_indices.numpy()
+        self.edges = edge_indices
 
     def _get_edge_weights(self):
-        pass
+        self.edge_weights = np.ones(self.edges.shape[1])
 
     def _get_features(self):
-        pass
+        self.features = []
+        time_x = np.transpose(self.X, (2,0,1))
+        for time in range(len(time_x)):
+            self.features.append(time_x[time])
+
 
     def _get_targets(self):
         pass

--- a/torch_geometric_temporal/data/dataset/metr_la.py
+++ b/torch_geometric_temporal/data/dataset/metr_la.py
@@ -19,12 +19,19 @@ class METRLADatasetLoader(object):
         super(METRLADatasetLoader, self).__init__()
         self._read_web_data()
 
+    def _download_url(self, url, save_path):
+        with urllib.request.urlopen(url) as dl_file:
+            with open(save_path, 'wb') as out_file:
+                out_file.write(dl_file.read())
+
     def _read_web_data(self):
-        url = "placeholder"
+        url = "https://graphmining.ai/temporal_datasets/METR-LA.zip"
 
         # Check if zip file is in data folder from working directory, otherwise download
         if (not os.path.isfile("data/METR-LA.zip")):
-            urllib.request.urlopen(url).read()
+            if not os.path.exists("data"):
+                os.makedirs("data")
+            self._download_url(url, "data/METR-LA.zip")
 
         if (not os.path.isfile("data/adj_mat.npy") or not os.path.isfile("data/node_values.npy")):
             with zipfile.ZipFile("data/METR-LA.zip", "r") as zip_fh:

--- a/torch_geometric_temporal/data/dataset/metr_la.py
+++ b/torch_geometric_temporal/data/dataset/metr_la.py
@@ -12,3 +12,35 @@ class METRLADatasetLoader(object):
 
     def __init__(self, arg):
         super(MetrlaDatasetLoader, self).__init__()
+
+    def _read_web_data(self):
+        url = "placeholder"
+        pass
+
+    def _get_edges(self):
+        pass
+
+    def _get_edge_weights(self):
+        pass
+
+    def _get_features(self):
+        pass
+
+    def _get_targets(self):
+        pass
+
+    def get_dataset(self) -> StaticGraphDiscreteSignal:
+        """Returns data iterator for METR-LA dataset as an instance of the
+        static graph discrete signal class.
+
+        Return types:
+            * **dataset** *(StaticGraphDiscrete Signal)* - The METR-LA traffic
+                forecasting dataset.
+        """
+        self._get_edges()
+        self._get_edge_weights()
+        self._get_features()
+        self._get_targets()
+        dataset = StaticGraphDiscreteSignal(self.edges, self.edge_weights, self.features, self.targets)
+
+        return dataset

--- a/torch_geometric_temporal/data/dataset/metr_la.py
+++ b/torch_geometric_temporal/data/dataset/metr_la.py
@@ -42,13 +42,12 @@ class METRLADatasetLoader(object):
         self.A = torch.from_numpy(A)
         self.X = torch.from_numpy(X)
 
-    def _get_edges(self):
+    def _get_edges_and_weights(self):
         edge_indices, values = dense_to_sparse(self.A)
         edge_indices = edge_indices.numpy()
+        values = values.numpy()
         self.edges = edge_indices
-
-    def _get_edge_weights(self):
-        self.edge_weights = np.ones(self.edges.shape[1])
+        self.edge_weights = values
 
     def _generate_task(self, num_timesteps_in: int=12, num_timesteps_out: int=12):
         """Uses the node features of the graph and generates a feature/target
@@ -72,7 +71,6 @@ class METRLADatasetLoader(object):
                 forecasting dataset.
         """
         self._get_edges()
-        self._get_edge_weights()
         self._generate_task(num_timesteps_in, num_timesteps_out)
         dataset = StaticGraphDiscreteSignal(self.edges, self.edge_weights, self.features, self.targets)
 

--- a/torch_geometric_temporal/data/dataset/metr_la.py
+++ b/torch_geometric_temporal/data/dataset/metr_la.py
@@ -60,7 +60,18 @@ class METRLADatasetLoader(object):
             num_timesteps_in (int): number of timesteps the sequence model sees
             num_timesteps_out (int): number of timesteps the sequence model has to predict
         """
-        pass
+        indices = [(i, i + (num_timesteps_input + num_timesteps_output)) for i
+                   in range(self.X.shape[2] - (
+                    num_timesteps_input + num_timesteps_output) + 1)]
+
+        # Generate observations
+        features, target = [], []
+        for i, j in indices:
+            features.append(self.X[:, :, i: i + num_timesteps_input])
+            target.append(X[:, 0, i + num_timesteps_input: j])
+
+        self.features = features
+        self.targets = target
 
     def get_dataset(self, num_timesteps_in: int=12, num_timesteps_out: int=12) -> StaticGraphDiscreteSignal:
         """Returns data iterator for METR-LA dataset as an instance of the

--- a/torch_geometric_temporal/data/dataset/metr_la.py
+++ b/torch_geometric_temporal/data/dataset/metr_la.py
@@ -15,9 +15,11 @@ class METRLADatasetLoader(object):
     to June 2012.
     """
 
-    def __init__(self):
+    def __init__(self, raw_data_dir=os.path.join(os.getcwd(), "data")):
         super(METRLADatasetLoader, self).__init__()
+        self.raw_data_dir = raw_data_dir
         self._read_web_data()
+
 
     def _download_url(self, url, save_path):
         with urllib.request.urlopen(url) as dl_file:
@@ -28,17 +30,17 @@ class METRLADatasetLoader(object):
         url = "https://graphmining.ai/temporal_datasets/METR-LA.zip"
 
         # Check if zip file is in data folder from working directory, otherwise download
-        if (not os.path.isfile("data/METR-LA.zip")):
-            if not os.path.exists("data"):
-                os.makedirs("data")
-            self._download_url(url, "data/METR-LA.zip")
+        if (not os.path.isfile(os.path.join(self.raw_data_dir, "METR-LA.zip"))):
+            if not os.path.exists(self.raw_data_dir):
+                os.makedirs(self.raw_data_dir)
+            self._download_url(url, os.path.join(self.raw_data_dir, "METR-LA.zip"))
 
-        if (not os.path.isfile("data/adj_mat.npy") or not os.path.isfile("data/node_values.npy")):
-            with zipfile.ZipFile("data/METR-LA.zip", "r") as zip_fh:
-                zip_fh.extractall("data/")
+        if (not os.path.isfile(os.path.join(self.raw_data_dir, "adj_mat.npy")) or not os.path.isfile(os.path.join(self.raw_data_dir, "node_values.npy"))):
+            with zipfile.ZipFile(os.path.join(self.raw_data_dir, "METR-LA.zip"), "r") as zip_fh:
+                zip_fh.extractall(self.raw_data_dir)
 
-        A = np.load("data/adj_mat.npy")
-        X = np.load("data/node_values.npy").transpose((1,2,0))
+        A = np.load(os.path.join(self.raw_data_dir, "adj_mat.npy"))
+        X = np.load(os.path.join(self.raw_data_dir, "node_values.npy")).transpose((1,2,0))
         X = X.astype(np.float32)
 
         # Normalise as in DCRNN paper (via Z-Score Method)
@@ -95,8 +97,8 @@ class METRLADatasetLoader(object):
 
         return dataset
 
-# Manual test
+
 if __name__ == '__main__':
     from torch_geometric_temporal.data.discrete.static_graph_discrete_signal import StaticGraphDiscreteSignal
-    loader = METRLADatasetLoader()
+    loader = METRLADatasetLoader(raw_data_dir="/tmp/")
     dataset = loader.get_dataset()

--- a/torch_geometric_temporal/data/dataset/pems_bay.py
+++ b/torch_geometric_temporal/data/dataset/pems_bay.py
@@ -44,7 +44,7 @@ class PemsBayDatasetLoader(object):
         self.edges = edge_indices
         self.edge_weights = values
 
-    def _generate_task(self, num_timesteps_in: int=12, num_timesteps_out: int=2):
+    def _generate_task(self, num_timesteps_in: int=12, num_timesteps_out: int=12):
         """Uses the node features of the graph and generates a feature/target
         relationship of the shape
         (num_nodes, num_node_features, num_timesteps_in) -> (num_nodes, num_timesteps_out)
@@ -69,7 +69,7 @@ class PemsBayDatasetLoader(object):
         self.targets = target
 
 
-    def get_dataset(self, num_timesteps_in: int=12, num_timesteps_out: int=2):
+    def get_dataset(self, num_timesteps_in: int=12, num_timesteps_out: int=12):
         """Returns data iterator for PEMS-BAY dataset as an instance of the
         static graph discrete signal class.
 

--- a/torch_geometric_temporal/data/dataset/pems_bay.py
+++ b/torch_geometric_temporal/data/dataset/pems_bay.py
@@ -11,24 +11,46 @@ class PemsBayDatasetLoader(object):
     """
 
     def __init__(self):
-        super(PemsBayDatasetLoader, self).__init()
+        super(PemsBayDatasetLoader, self).__init__()
         self._read_web_data()
 
-    def _read_web_data():
+    def _read_web_data(self):
         url = "placeholder"
-        pass
+        
+        if (not os.path.isfile("data/PEMS-BAY.zip")):
+            urllib.request.urlopen(url).read()
+
+        if (not os.path.isfile("data/pems_adj_mat.npy") or not os.path.isfile("data/pems_node_values.npy")):
+            with zipfile.ZipFile("data/PEMS-BAY.zip", "r") as zip_fh:
+                zip_fh.extractall("data/")
+
+        A = np.load("data/pems_adj_mat.npy")
+        X = np.load("data/pems_node_values.npy").transpose((1,2,0))
+        X = X.astype(np.float32)
+
+        # Normalise as in DCRNN paper (via Z-Score Method)
+        means = np.mean(X, axis=(0, 2))
+        X = X - means.reshape(1, -1, 1)
+        stds = np.std(X, axis=(0, 2))
+        X = X / stds.reshape(1, -1, 1)
+        
+        self.A = torch.from_numpy(A)
+        self.X = torch.from_numpy(X)
 
     def _get_edges_and_weights(self):
-        pass
+        edge_indices, values = dense_to_sparse(self.A)
+        edge_indices = edge_indices.numpy()
+        values = values.numpy()
+        self.edges = edge_indices
+        self.edge_weights = values
 
     def _generate_task(self, num_timesteps_in: int=12, num_timesteps_out: int=2):
         pass
-
+        
     def get_dataset(self, num_timesteps_in: int=12, num_timesteps_out: int=2):
         pass
 
 if __name__ == '__main__':
-    pass
-
-
-
+    from torch_geometric_temporal.data.discrete.static_graph_discrete_signal import StaticGraphDiscreteSignal
+    loader = PemsBayDatasetLoader()
+    dataset = loader.get_dataset()

--- a/torch_geometric_temporal/data/dataset/pems_bay.py
+++ b/torch_geometric_temporal/data/dataset/pems_bay.py
@@ -1,0 +1,34 @@
+import os
+import zipfile
+import numpy as np
+import torch
+from torch_geometric.utils import dense_to_sparse
+from six.moves import urllib
+from torch_geometric_temporal.data.discrete.static_graph_discrete_signal import StaticGraphDiscreteSignal
+
+class PemsBayDatasetLoader(object):
+    """A traffic forecasting dataset as described in DCRNN paper
+    """
+
+    def __init__(self):
+        super(PemsBayDatasetLoader, self).__init()
+        self._read_web_data()
+
+    def _read_web_data():
+        url = "placeholder"
+        pass
+
+    def _get_edges_and_weights(self):
+        pass
+
+    def _generate_task(self, num_timesteps_in: int=12, num_timesteps_out: int=2):
+        pass
+
+    def get_dataset(self, num_timesteps_in: int=12, num_timesteps_out: int=2):
+        pass
+
+if __name__ == '__main__':
+    pass
+
+
+

--- a/torch_geometric_temporal/data/dataset/pems_bay.py
+++ b/torch_geometric_temporal/data/dataset/pems_bay.py
@@ -14,11 +14,18 @@ class PemsBayDatasetLoader(object):
         super(PemsBayDatasetLoader, self).__init__()
         self._read_web_data()
 
+    def _download_url(self, url, save_path):
+        with urllib.request.urlopen(url) as dl_file:
+            with open(save_path, 'wb') as out_file:
+                out_file.write(dl_file.read())
+
     def _read_web_data(self):
-        url = "placeholder"
+        url = "https://graphmining.ai/temporal_datasets/PEMS-BAY.zip"
         
         if (not os.path.isfile("data/PEMS-BAY.zip")):
-            urllib.request.urlopen(url).read()
+            if not os.path.exists("data"):
+                os.makedirs("data")
+            self._download_url(url, "data/PEMS-BAY.zip")
 
         if (not os.path.isfile("data/pems_adj_mat.npy") or not os.path.isfile("data/pems_node_values.npy")):
             with zipfile.ZipFile("data/PEMS-BAY.zip", "r") as zip_fh:
@@ -63,7 +70,7 @@ class PemsBayDatasetLoader(object):
         features, target = [], []
         for i, j in indices:
             features.append((self.X[:, :, i: i + num_timesteps_in]).numpy())
-            target.append((self.X[:, 0, i + num_timesteps_in: j]).numpy())
+            target.append((self.X[:, :, i + num_timesteps_in: j]).numpy())
 
         self.features = features
         self.targets = target

--- a/torch_geometric_temporal/data/dataset/pems_bay.py
+++ b/torch_geometric_temporal/data/dataset/pems_bay.py
@@ -10,8 +10,9 @@ class PemsBayDatasetLoader(object):
     """A traffic forecasting dataset as described in DCRNN paper
     """
 
-    def __init__(self):
+    def __init__(self, raw_data_dir=os.path.join(os.getcwd(), "data")):
         super(PemsBayDatasetLoader, self).__init__()
+        self.raw_data_dir = raw_data_dir
         self._read_web_data()
 
     def _download_url(self, url, save_path):
@@ -22,17 +23,18 @@ class PemsBayDatasetLoader(object):
     def _read_web_data(self):
         url = "https://graphmining.ai/temporal_datasets/PEMS-BAY.zip"
         
-        if (not os.path.isfile("data/PEMS-BAY.zip")):
-            if not os.path.exists("data"):
-                os.makedirs("data")
-            self._download_url(url, "data/PEMS-BAY.zip")
+        # Check if zip file is in data folder from working directory, otherwise download
+        if (not os.path.isfile(os.path.join(self.raw_data_dir, "PEMS-BAY.zip"))):
+            if not os.path.exists(self.raw_data_dir):
+                os.makedirs(self.raw_data_dir)
+            self._download_url(url, os.path.join(self.raw_data_dir, "PEMS-BAY.zip"))
 
-        if (not os.path.isfile("data/pems_adj_mat.npy") or not os.path.isfile("data/pems_node_values.npy")):
-            with zipfile.ZipFile("data/PEMS-BAY.zip", "r") as zip_fh:
-                zip_fh.extractall("data/")
+        if (not os.path.isfile(os.path.join(self.raw_data_dir, "pems_adj_mat.npy")) or not os.path.isfile(os.path.join(self.raw_data_dir, "pems_node_values.npy"))):
+            with zipfile.ZipFile(os.path.join(self.raw_data_dir, "PEMS-BAY.zip"), "r") as zip_fh:
+                zip_fh.extractall(self.raw_data_dir)
 
-        A = np.load("data/pems_adj_mat.npy")
-        X = np.load("data/pems_node_values.npy").transpose((1,2,0))
+        A = np.load(os.path.join(self.raw_data_dir, "pems_adj_mat.npy"))
+        X = np.load(os.path.join(self.raw_data_dir, "pems_node_values.npy")).transpose((1,2,0))
         X = X.astype(np.float32)
 
         # Normalise as in DCRNN paper (via Z-Score Method)
@@ -92,5 +94,5 @@ class PemsBayDatasetLoader(object):
 
 if __name__ == '__main__':
     from torch_geometric_temporal.data.discrete.static_graph_discrete_signal import StaticGraphDiscreteSignal
-    loader = PemsBayDatasetLoader()
+    loader = PemsBayDatasetLoader(raw_data_dir="/tmp/")
     dataset = loader.get_dataset()


### PR DESCRIPTION
DataLoaders for METR-LA and PEMS-BAY traffic forecasting datasets.

Includes:

- `METRLADatasetLoader` - raw data downloaded from graphmining.ai and saved in user specified directory
- `PemsBayDatasetLoader` - raw data downloaded from graphmining.ai and saved in user specified directory
- Associated tests in `dataset_test.py` one for default task from DCRNN paper and one with custom task specification
- Appropriate changes in `__init__.py` files for packaging