### PR TITLE
Fix small typo in documentation

### DIFF
--- a/docs/source/notes/introduction.rst
+++ b/docs/source/notes/introduction.rst
@@ -107,7 +107,7 @@ The Hungarian Chickenpox Dataset can be loaded by the following code snippet. Th
 
     dataset = loader.get_dataset()
 
-Smatiotemporal Signal Splitting
+Spatiotemporal Signal Splitting
 -------------------------------
 
 


### PR DESCRIPTION
- In the section **Data Structures** of the documentation says _"Smatiotemporal Signal Splitting"_ and it should say _"Spatiotemporal Signal Splitting"_