### PR TITLE
Required Python version to installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ If you notice anything unexpected, please open an [issue](https://benedekrozembe
 
 **Installation**
 
+Binaries are provided for Python version <= 3.8.
 
 **PyTorch 1.8.0**
 

--- a/docs/source/notes/installation.rst
+++ b/docs/source/notes/installation.rst
@@ -2,7 +2,7 @@ Installation
 ============
 
 The installation of PyTorch Geometric Temporal requires the presence of certain prerequisites. These are described in great detail in the installation description of PyTorch Geometric. Please follow the instructions laid out `here <https://pytorch-geometric.readthedocs.io/en/latest/notes/installation.html>`_. You might also take a look at the `readme file <https://github.com/benedekrozemberczki/pytorch_geometric_temporal>`_ of the PyTorch Geometric Temporal repository.
-
+Binaries are provided for Python version <= 3.8.
 
 **PyTorch 1.8.0**
 


### PR DESCRIPTION
**Documentation enhancement**

- Add Python version specification when installing PyTorch Geometric Temporal (PGT) via binaries in the README file and Documentation

The Python version required is not specified in the README file, neither the documentation.
This addition in the README file and in the docs aims to minimize the scenario of a user trying to install PGT via binaries without reading the PyTorch Geometric (PG) documentation and using a higher Python version, for example the latest Python 3.9.

This similar enhancement was added today to PG in [this PR](https://github.com/rusty1s/pytorch_geometric/pull/2718). As PGT depends on PG, this dependency on Python version <= 3.8 is required for PGT.