### PR TITLE
evolvegcno example: init of class

### DIFF
--- a/examples/recurrent/evolvegcno_example.py
+++ b/examples/recurrent/evolvegcno_example.py
@@ -16,8 +16,8 @@ train_dataset, test_dataset = temporal_signal_split(dataset, train_ratio=0.2)
 class RecurrentGCN(torch.nn.Module):
     def __init__(self, node_features):
         super(RecurrentGCN, self).__init__()
-        self.recurrent = EvolveGCNO(node_features, 4)
-        self.linear = torch.nn.Linear(4, 1)
+        self.recurrent = EvolveGCNO(node_features)
+        self.linear = torch.nn.Linear(node_features, 1)
 
     def forward(self, x, edge_index, edge_weight):
         h = self.recurrent(x, edge_index, edge_weight)


### PR DESCRIPTION
In the EvolveGCNO class, one only requires one input to initialize instead of two. The two "4" in lines 19 and 20 should be replaced by "node_features" and the extra "node_features" should be removed.