### PR TITLE
Fixed EvolveGCN weight squeezing

### DIFF
--- a/torch_geometric_temporal/nn/recurrent/evolvegcnh.py
+++ b/torch_geometric_temporal/nn/recurrent/evolvegcnh.py
@@ -95,5 +95,5 @@ class EvolveGCNH(torch.nn.Module):
             self.weight = self.initial_weight.data
         W = self.weight[None, :, :]
         X_tilde, W = self.recurrent_layer(X_tilde, W)
-        X = self.conv_layer(W.squeeze(), X, edge_index, edge_weight)
+        X = self.conv_layer(W.squeeze(dim=0), X, edge_index, edge_weight)
         return X

--- a/torch_geometric_temporal/nn/recurrent/evolvegcno.py
+++ b/torch_geometric_temporal/nn/recurrent/evolvegcno.py
@@ -184,6 +184,6 @@ class EvolveGCNO(torch.nn.Module):
             self.weight = self.initial_weight.data
         W = self.weight[None, :, :]
         _, W = self.recurrent_layer(W, W)
-        X = self.conv_layer(W.squeeze(), X, edge_index, edge_weight)
+        X = self.conv_layer(W.squeeze(dim=0), X, edge_index, edge_weight)
     
         return X


### PR DESCRIPTION
Made squeeze dimension explicit, in order to avoid collapsing all dimensions for in_channels=1