### PR TITLE
Make attention trainable in A3TGCN and make it support batches

### DIFF
--- a/examples/recurrent/a3tgcn2_example.py
+++ b/examples/recurrent/a3tgcn2_example.py
@@ -1,0 +1,176 @@
+# I published a working notebook of this example at https://www.kaggle.com/elmahy/a3t-gcn-for-traffic-forecasting
+
+# The contribution makes training possible because it support batches of data 
+
+
+import numpy as np
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+
+import torch
+import torch.nn.functional as F
+from torch_geometric.nn import GCNConv
+from torch_geometric_temporal.nn.recurrent import A3TGCN2
+# GPU support
+DEVICE = torch.device('cuda') # cuda
+shuffle=True
+batch_size = 32
+
+
+
+#Dataset
+#Traffic forecasting dataset based on Los Angeles Metropolitan traffic
+#207 loop detectors on highways
+#March 2012 - June 2012
+#From the paper: Diffusion Convolutional Recurrent Neural Network
+
+
+from torch_geometric_temporal.dataset import METRLADatasetLoader
+loader = METRLADatasetLoader()
+dataset = loader.get_dataset(num_timesteps_in=12, num_timesteps_out=12)
+print("Dataset type:  ", dataset)
+print("Number of samples / sequences: ",  len(set(dataset)))
+
+
+# Visualize traffic over time
+sensor_number = 1
+hours = 24
+sensor_labels = [bucket.y[sensor_number][0].item() for bucket in list(dataset)[:hours]]
+plt.plot(sensor_labels)
+
+# Train test split 
+
+from torch_geometric_temporal.signal import temporal_signal_split
+train_dataset, test_dataset = temporal_signal_split(dataset, train_ratio=0.8)
+
+print("Number of train buckets: ", len(set(train_dataset)))
+print("Number of test buckets: ", len(set(test_dataset)))
+
+
+# Creating Dataloaders
+
+train_input = np.array(train_dataset.features) # (27399, 207, 2, 12)
+train_target = np.array(train_dataset.targets) # (27399, 207, 12)
+train_x_tensor = torch.from_numpy(train_input).type(torch.FloatTensor).to(DEVICE)  # (B, N, F, T)
+train_target_tensor = torch.from_numpy(train_target).type(torch.FloatTensor).to(DEVICE)  # (B, N, T)
+train_dataset_new = torch.utils.data.TensorDataset(train_x_tensor, train_target_tensor)
+train_loader = torch.utils.data.DataLoader(train_dataset_new, batch_size=batch_size, shuffle=shuffle,drop_last=True)
+
+
+test_input = np.array(test_dataset.features) # (, 207, 2, 12)
+test_target = np.array(test_dataset.targets) # (, 207, 12)
+test_x_tensor = torch.from_numpy(test_input).type(torch.FloatTensor).to(DEVICE)  # (B, N, F, T)
+test_target_tensor = torch.from_numpy(test_target).type(torch.FloatTensor).to(DEVICE)  # (B, N, T)
+test_dataset_new = torch.utils.data.TensorDataset(test_x_tensor, test_target_tensor)
+test_loader = torch.utils.data.DataLoader(test_dataset_new, batch_size=batch_size, shuffle=shuffle,drop_last=True)
+
+
+
+# Making the model 
+class TemporalGNN(torch.nn.Module):
+    def __init__(self, node_features, periods, batch_size):
+        super(TemporalGNN, self).__init__()
+        # Attention Temporal Graph Convolutional Cell
+        self.tgnn = A3TGCN2(in_channels=node_features,  out_channels=32, periods=periods,batch_size=batch_size) # node_features=2, periods=12
+        # Equals single-shot prediction
+        self.linear = torch.nn.Linear(32, periods)
+
+    def forward(self, x, edge_index):
+        """
+        x = Node features for T time steps
+        edge_index = Graph edge indices
+        """
+        h = self.tgnn(x, edge_index) # x [b, 207, 2, 12]  returns h [b, 207, 12]
+        h = F.relu(h) 
+        h = self.linear(h)
+        return h
+
+TemporalGNN(node_features=2, periods=12, batch_size=2)
+
+
+
+# Create model and optimizers
+model = TemporalGNN(node_features=2, periods=12, batch_size=batch_size).to(DEVICE)
+optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
+loss_fn = torch.nn.MSELoss()
+
+
+print('Net\'s state_dict:')
+total_param = 0
+for param_tensor in model.state_dict():
+    print(param_tensor, '\t', model.state_dict()[param_tensor].size())
+    total_param += np.prod(model.state_dict()[param_tensor].size())
+print('Net\'s total params:', total_param)
+#--------------------------------------------------
+print('Optimizer\'s state_dict:')  # If you notice here the Attention is a trainable parameter
+for var_name in optimizer.state_dict():
+    print(var_name, '\t', optimizer.state_dict()[var_name])
+
+
+
+# Loading the graph once because it's a static graph
+
+for snapshot in train_dataset:
+    static_edge_index = snapshot.edge_index.to(DEVICE)
+    break;
+
+
+
+# Training the model 
+model.train()
+
+for epoch in range(30):
+    step = 0
+    loss_list = []
+    for encoder_inputs, labels in train_loader:
+        y_hat = model(encoder_inputs, static_edge_index)         # Get model predictions
+        loss = loss_fn(y_hat, labels) # Mean squared error #loss = torch.mean((y_hat-labels)**2)  sqrt to change it to rmse
+        loss.backward()
+        optimizer.step()
+        optimizer.zero_grad()
+        step= step+ 1
+        loss_list.append(loss.item())
+        if step % 100 == 0 :
+            print(sum(loss_list)/len(loss_list))
+    print("Epoch {} train RMSE: {:.4f}".format(epoch, sum(loss_list)/len(loss_list)))
+
+
+## Evaluation
+
+#- Lets get some sample predictions for a specific horizon (e.g. 288/12 = 24 hours)
+#- The model always gets one hour and needs to predict the next hour
+
+model.eval()
+step = 0
+# Store for analysis
+total_loss = []
+for encoder_inputs, labels in test_loader:
+    # Get model predictions
+    y_hat = model(encoder_inputs, static_edge_index)
+    # Mean squared error
+    loss = loss_fn(y_hat, labels)
+    total_loss.append(loss.item())
+    # Store for analysis below
+    #test_labels.append(labels)
+    #predictions.append(y_hat)
+    
+
+print("Test MSE: {:.4f}".format(sum(total_loss)/len(total_loss)))
+
+
+### Visualization
+
+#- The further away the point in time is, the worse the predictions get
+#- Predictions shape: [num_data_points, num_sensors, num_timesteps]
+
+
+sensor = 123
+timestep = 11 
+preds = np.asarray([pred[sensor][timestep].detach().cpu().numpy() for pred in y_hat])
+labs  = np.asarray([label[sensor][timestep].cpu().numpy() for label in labels])
+print("Data points:,", preds.shape)
+
+plt.figure(figsize=(20,5))
+sns.lineplot(data=preds, label="pred")
+sns.lineplot(data=labs, label="true")

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requires = [
     "torch_scatter",
     "torch_cluster",
     "torch_spline_conv",
-    "torch_geometric",
+    "torch_geometric==1.7.0",
     "numpy",
     "scipy",
     "tqdm",

--- a/test/recurrent_test.py
+++ b/test/recurrent_test.py
@@ -8,6 +8,7 @@ from torch_geometric_temporal.nn.recurrent import (
     EvolveGCNO,
     TGCN,
     A3TGCN,
+    A3TGCN2,
     MPNNLSTM,
 )
 

--- a/torch_geometric_temporal/nn/recurrent/__init__.py
+++ b/torch_geometric_temporal/nn/recurrent/__init__.py
@@ -7,6 +7,8 @@ from .evolvegcnh import EvolveGCNH
 from .evolvegcno import EvolveGCNO
 from .dcrnn import DCRNN
 from .temporalgcn import TGCN
+from .temporalgcn import TGCN2
 from .attentiontemporalgcn import A3TGCN
+from .attentiontemporalgcn import A3TGCN2
 from .mpnn_lstm import MPNNLSTM
 from .agcrn import AGCRN

--- a/torch_geometric_temporal/nn/recurrent/attentiontemporalgcn.py
+++ b/torch_geometric_temporal/nn/recurrent/attentiontemporalgcn.py
@@ -46,7 +46,7 @@ class A3TGCN(torch.nn.Module):
             add_self_loops=self.add_self_loops,
         )
         device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-        self._attention = nn.Parameter(torch.empty(self.periods, device=device))
+        self._attention = torch.nn.Parameter(torch.empty(self.periods, device=device))
         torch.nn.init.uniform_(self._attention)
 
     def forward(

--- a/torch_geometric_temporal/nn/recurrent/attentiontemporalgcn.py
+++ b/torch_geometric_temporal/nn/recurrent/attentiontemporalgcn.py
@@ -1,5 +1,6 @@
 import torch
 from .temporalgcn import TGCN
+from .temporalgcn import TGCN2
 from torch_geometric.nn import GCNConv
 
 
@@ -75,4 +76,64 @@ class A3TGCN(torch.nn.Module):
             H_accum = H_accum + probs[period] * self._base_tgcn(
                 X[:, :, period], edge_index, edge_weight, H
             )
+        return H_accum
+
+
+
+class A3TGCN2(torch.nn.Module):
+    r"""An implementation THAT SUPPORTS BATCHES of the Attention Temporal Graph Convolutional Cell.
+    For details see this paper: `"A3T-GCN: Attention Temporal Graph Convolutional
+    Network for Traffic Forecasting." <https://arxiv.org/abs/2006.11583>`_
+
+    Args:
+        in_channels (int): Number of input features.
+        out_channels (int): Number of output features.
+        periods (int): Number of time periods.
+        improved (bool): Stronger self loops (default :obj:`False`).
+        cached (bool): Caching the message weights (default :obj:`False`).
+        add_self_loops (bool): Adding self-loops for smoothing (default :obj:`True`).
+    """
+
+    def __init__( self, in_channels: int,  out_channels: int,  periods: int, batch_size:int, improved: bool = False,
+                 cached: bool = False, add_self_loops: bool = True):
+        super(A3TGCN2, self).__init__()
+
+        self.in_channels = in_channels  # 2
+        self.out_channels = out_channels # 32
+        self.periods = periods # 12
+        self.improved = improved
+        self.cached = cached
+        self.add_self_loops = add_self_loops
+        self.batch_size = batch_size
+        self._setup_layers()
+
+    def _setup_layers(self):
+        self._base_tgcn = TGCN2(in_channels=self.in_channels, out_channels=self.out_channels,  batch_size=self.batch_size,
+                               improved=self.improved,cached=self.cached, add_self_loops=self.add_self_loops)
+        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        self._attention = torch.nn.Parameter(torch.empty(self.periods, device=device))
+        torch.nn.init.uniform_(self._attention)
+
+    def forward( self, X: torch.FloatTensor,edge_index: torch.LongTensor, edge_weight: torch.FloatTensor = None,
+                H: torch.FloatTensor = None) -> torch.FloatTensor:
+        """
+        Making a forward pass. If edge weights are not present the forward pass
+        defaults to an unweighted graph. If the hidden state matrix is not present
+        when the forward pass is called it is initialized with zeros.
+
+        Arg types:
+            * **X** (PyTorch Float Tensor): Node features for T time periods.
+            * **edge_index** (PyTorch Long Tensor): Graph edge indices.
+            * **edge_weight** (PyTorch Long Tensor, optional)*: Edge weight vector.
+            * **H** (PyTorch Float Tensor, optional): Hidden state matrix for all nodes.
+
+        Return types:
+            * **H** (PyTorch Float Tensor): Hidden state matrix for all nodes.
+        """
+        H_accum = 0
+        probs = torch.nn.functional.softmax(self._attention, dim=0)
+        for period in range(self.periods):
+
+            H_accum = H_accum + probs[period] * self._base_tgcn( X[:, :, :, period], edge_index, edge_weight, H) #([32, 207, 32]
+
         return H_accum

--- a/torch_geometric_temporal/nn/recurrent/attentiontemporalgcn.py
+++ b/torch_geometric_temporal/nn/recurrent/attentiontemporalgcn.py
@@ -24,7 +24,7 @@ class A3TGCN(torch.nn.Module):
         periods: int,
         improved: bool = False,
         cached: bool = False,
-        add_self_loops: bool = True,
+        add_self_loops: bool = True
     ):
         super(A3TGCN, self).__init__()
 
@@ -44,7 +44,8 @@ class A3TGCN(torch.nn.Module):
             cached=self.cached,
             add_self_loops=self.add_self_loops,
         )
-        self._attention = torch.empty(self.periods)
+        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        self._attention = nn.Parameter(torch.empty(self.periods, device=device))
         torch.nn.init.uniform_(self._attention)
 
     def forward(

--- a/torch_geometric_temporal/nn/recurrent/attentiontemporalgcn.py
+++ b/torch_geometric_temporal/nn/recurrent/attentiontemporalgcn.py
@@ -94,8 +94,15 @@ class A3TGCN2(torch.nn.Module):
         add_self_loops (bool): Adding self-loops for smoothing (default :obj:`True`).
     """
 
-    def __init__( self, in_channels: int,  out_channels: int,  periods: int, batch_size:int, improved: bool = False,
-                 cached: bool = False, add_self_loops: bool = True):
+    def __init__(
+        self,
+        in_channels: int, 
+        out_channels: int,  
+        periods: int, 
+        batch_size:int, 
+        improved: bool = False,
+        cached: bool = False,
+        add_self_loops: bool = True):
         super(A3TGCN2, self).__init__()
 
         self.in_channels = in_channels  # 2
@@ -108,14 +115,25 @@ class A3TGCN2(torch.nn.Module):
         self._setup_layers()
 
     def _setup_layers(self):
-        self._base_tgcn = TGCN2(in_channels=self.in_channels, out_channels=self.out_channels,  batch_size=self.batch_size,
-                               improved=self.improved,cached=self.cached, add_self_loops=self.add_self_loops)
+        self._base_tgcn = TGCN2(
+            in_channels=self.in_channels,
+            out_channels=self.out_channels,  
+            batch_size=self.batch_size,
+            improved=self.improved,
+            cached=self.cached, 
+            add_self_loops=self.add_self_loops)
+
         device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self._attention = torch.nn.Parameter(torch.empty(self.periods, device=device))
         torch.nn.init.uniform_(self._attention)
 
-    def forward( self, X: torch.FloatTensor,edge_index: torch.LongTensor, edge_weight: torch.FloatTensor = None,
-                H: torch.FloatTensor = None) -> torch.FloatTensor:
+    def forward( 
+        self, 
+        X: torch.FloatTensor,
+        edge_index: torch.LongTensor, 
+        edge_weight: torch.FloatTensor = None,
+        H: torch.FloatTensor = None
+    ) -> torch.FloatTensor:
         """
         Making a forward pass. If edge weights are not present the forward pass
         defaults to an unweighted graph. If the hidden state matrix is not present

--- a/torch_geometric_temporal/nn/recurrent/temporalgcn.py
+++ b/torch_geometric_temporal/nn/recurrent/temporalgcn.py
@@ -128,3 +128,103 @@ class TGCN(torch.nn.Module):
         H_tilde = self._calculate_candidate_state(X, edge_index, edge_weight, H, R)
         H = self._calculate_hidden_state(Z, H, H_tilde)
         return H
+
+
+class TGCN2(torch.nn.Module):
+    r"""An implementation THAT SUPPORTS BATCHES of the Temporal Graph Convolutional Gated Recurrent Cell.
+    For details see this paper: `"T-GCN: A Temporal Graph ConvolutionalNetwork for
+    Traffic Prediction." <https://arxiv.org/abs/1811.05320>`_
+
+    Args:
+        in_channels (int): Number of input features.
+        out_channels (int): Number of output features.
+        batch_size (int): Size of the batch.
+        improved (bool): Stronger self loops. Default is True.
+        cached (bool): Caching the message weights. Default is False.
+        add_self_loops (bool): Adding self-loops for smoothing. Default is True.
+    """
+
+    def __init__(self, in_channels: int, out_channels: int, batch_size: int, improved: bool = False, cached: bool = False, 
+                 add_self_loops: bool = True):
+        super(TGCN2, self).__init__()
+
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.improved = improved
+        self.cached = cached
+        self.add_self_loops = add_self_loops
+        self.batch_size = batch_size
+        self._create_parameters_and_layers()
+
+    def _create_update_gate_parameters_and_layers(self):
+        self.conv_z = GCNConv(in_channels=self.in_channels,  out_channels=self.out_channels, improved=self.improved,
+                              cached=self.cached, add_self_loops=self.add_self_loops )
+        self.linear_z = torch.nn.Linear(2 * self.out_channels, self.out_channels)
+
+    def _create_reset_gate_parameters_and_layers(self):
+        self.conv_r = GCNConv(in_channels=self.in_channels, out_channels=self.out_channels, improved=self.improved,
+                              cached=self.cached, add_self_loops=self.add_self_loops )
+        self.linear_r = torch.nn.Linear(2 * self.out_channels, self.out_channels)
+
+    def _create_candidate_state_parameters_and_layers(self):
+        self.conv_h = GCNConv(in_channels=self.in_channels, out_channels=self.out_channels, improved=self.improved,
+                              cached=self.cached, add_self_loops=self.add_self_loops )
+        self.linear_h = torch.nn.Linear(2 * self.out_channels, self.out_channels)
+
+    def _create_parameters_and_layers(self):
+        self._create_update_gate_parameters_and_layers()
+        self._create_reset_gate_parameters_and_layers()
+        self._create_candidate_state_parameters_and_layers()
+
+    def _set_hidden_state(self, X, H):
+        if H is None:
+            H = torch.zeros(self.batch_size,X.shape[1], self.out_channels).to(X.device) #(b, 207, 32)
+        return H
+
+    def _calculate_update_gate(self, X, edge_index, edge_weight, H):
+        Z = torch.cat([self.conv_z(X, edge_index, edge_weight), H], axis=2) # (b, 207, 64)
+        Z = self.linear_z(Z) # (b, 207, 32)
+        Z = torch.sigmoid(Z)
+
+        return Z
+
+    def _calculate_reset_gate(self, X, edge_index, edge_weight, H):
+        R = torch.cat([self.conv_r(X, edge_index, edge_weight), H], axis=2) # (b, 207, 64)
+        R = self.linear_r(R) # (b, 207, 32)
+        R = torch.sigmoid(R)
+
+        return R
+
+    def _calculate_candidate_state(self, X, edge_index, edge_weight, H, R):
+        H_tilde = torch.cat([self.conv_h(X, edge_index, edge_weight), H * R], axis=2) # (b, 207, 64)
+        H_tilde = self.linear_h(H_tilde) # (b, 207, 32)
+        H_tilde = torch.tanh(H_tilde)
+
+        return H_tilde
+
+    def _calculate_hidden_state(self, Z, H, H_tilde):
+        H = Z * H + (1 - Z) * H_tilde   # # (b, 207, 32)
+        return H
+
+    def forward(self,X: torch.FloatTensor, edge_index: torch.LongTensor, edge_weight: torch.FloatTensor = None,
+                H: torch.FloatTensor = None ) -> torch.FloatTensor:
+        """
+        Making a forward pass. If edge weights are not present the forward pass
+        defaults to an unweighted graph. If the hidden state matrix is not present
+        when the forward pass is called it is initialized with zeros.
+
+        Arg types:
+            * **X** *(PyTorch Float Tensor)* - Node features.
+            * **edge_index** *(PyTorch Long Tensor)* - Graph edge indices.
+            * **edge_weight** *(PyTorch Long Tensor, optional)* - Edge weight vector.
+            * **H** *(PyTorch Float Tensor, optional)* - Hidden state matrix for all nodes.
+
+        Return types:
+            * **H** *(PyTorch Float Tensor)* - Hidden state matrix for all nodes.
+        """
+        H = self._set_hidden_state(X, H)
+        Z = self._calculate_update_gate(X, edge_index, edge_weight, H)
+        R = self._calculate_reset_gate(X, edge_index, edge_weight, H)
+        H_tilde = self._calculate_candidate_state(X, edge_index, edge_weight, H, R)
+        H = self._calculate_hidden_state(Z, H, H_tilde) # (b, 207, 32)
+        return H


### PR DESCRIPTION
I made a notebook here https://www.kaggle.com/elmahy/a3t-gcn-for-traffic-forecasting 
It shows an example A3TGCN. 

I contributed three things:
1. I used nn.Parameter  to make the attention trainable
If you checked the notebook for example in the end I print all the parameters of the model, in the current implementation the attention is not a trainable parameter which make it no different from the TGCN (which the authors published previously)

2. I made the code support batches of data
Instead of changing the current code which maybe in use for some other task, I added another class TGCN2 and A3TGCN2 which allows X to be in patches. In the current version, it's very slow to train on large dataset.

3. I provided a separate example.