### PR TITLE
Temporal signal split fix

### DIFF
--- a/test/dataset_test.py
+++ b/test/dataset_test.py
@@ -653,7 +653,7 @@ def test_train_test_split_dynamic_graph_static_signal():
             assert getattr(snapshot, "optional2").shape == (100, 32)
 
 
-def test_discrete_train_test_split_dynamic():
+def test_discrete_train_test_split_dynamic_graph_static_signal():
 
     snapshot_count = 250
     n_count = 100

--- a/test/dataset_test.py
+++ b/test/dataset_test.py
@@ -31,12 +31,19 @@ def get_edge_array(n_count):
     return np.array([edge for edge in nx.gnp_random_graph(n_count, 0.1).edges()]).T
 
 
-def generate_signal(snapshot_count, n_count, feature_count):
+def generate_signal(snapshot_count, n_count, feature_count, additional_features_keys=[]):
     edge_indices = [get_edge_array(n_count) for _ in range(snapshot_count)]
     edge_weights = [np.ones(edge_indices[t].shape[1]) for t in range(snapshot_count)]
     features = [
         np.random.uniform(0, 1, (n_count, feature_count)) for _ in range(snapshot_count)
     ]
+
+    if additional_features_keys:
+        additional_features = {
+            key: [np.random.uniform(0, 1, (n_count, feature_count)) for _ in range(snapshot_count)
+                  ] for key in additional_features_keys}
+        return edge_indices, edge_weights, features, additional_features
+
     return edge_indices, edge_weights, features
 
 
@@ -579,40 +586,14 @@ def test_discrete_train_test_split_dynamic():
     n_count = 100
     feature_count = 32
 
-    edge_indices, edge_weights, features = generate_signal(250, 100, 32)
+    edge_indices, edge_weights, features, additional_features = generate_signal(
+        250, 100, 32, ["optional1", "optional2"]
+    )
 
     targets = [np.random.uniform(0, 10, (n_count,)) for _ in range(snapshot_count)]
 
-    dataset = DynamicGraphTemporalSignal(edge_indices, edge_weights, features, targets)
-
-    train_dataset, test_dataset = temporal_signal_split(dataset, 0.8)
-
-    for epoch in range(2):
-        for snapshot in test_dataset:
-            assert snapshot.edge_index.shape[0] == 2
-            assert snapshot.edge_index.shape[1] == snapshot.edge_attr.shape[0]
-            assert snapshot.x.shape == (100, 32)
-            assert snapshot.y.shape == (100,)
-
-    for epoch in range(2):
-        for snapshot in train_dataset:
-            assert snapshot.edge_index.shape[0] == 2
-            assert snapshot.edge_index.shape[1] == snapshot.edge_attr.shape[0]
-            assert snapshot.x.shape == (100, 32)
-            assert snapshot.y.shape == (100,)
-
-
-def test_train_test_split_dynamic_graph_static_signal():
-
-    snapshot_count = 250
-    n_count = 100
-    feature_count = 32
-
-    edge_indices, edge_weights, features = generate_signal(250, 100, 32)
-
-    targets = [np.random.uniform(0, 10, (n_count,)) for _ in range(snapshot_count)]
-    dataset = StaticGraphTemporalSignal(
-        edge_indices[0], edge_weights[0], features, targets
+    dataset = DynamicGraphTemporalSignal(
+        edge_indices, edge_weights, features, targets, **additional_features
     )
 
     train_dataset, test_dataset = temporal_signal_split(dataset, 0.8)
@@ -623,6 +604,8 @@ def test_train_test_split_dynamic_graph_static_signal():
             assert snapshot.edge_index.shape[1] == snapshot.edge_attr.shape[0]
             assert snapshot.x.shape == (100, 32)
             assert snapshot.y.shape == (100,)
+            assert getattr(snapshot, "optional1").shape == (100, 32)
+            assert getattr(snapshot, "optional2").shape == (100, 32)
 
     for epoch in range(2):
         for snapshot in train_dataset:
@@ -630,21 +613,24 @@ def test_train_test_split_dynamic_graph_static_signal():
             assert snapshot.edge_index.shape[1] == snapshot.edge_attr.shape[0]
             assert snapshot.x.shape == (100, 32)
             assert snapshot.y.shape == (100,)
+            assert getattr(snapshot, "optional1").shape == (100, 32)
+            assert getattr(snapshot, "optional2").shape == (100, 32)
 
 
-def test_discrete_train_test_split_dynamic():
+def test_train_test_split_dynamic_graph_static_signal():
 
     snapshot_count = 250
     n_count = 100
     feature_count = 32
 
-    edge_indices, edge_weights, features = generate_signal(250, 100, 32)
-
-    feature = features[0]
+    edge_indices, edge_weights, features, additional_features = generate_signal(
+        250, 100, 32, ["optional1", "optional2"]
+    )
 
     targets = [np.random.uniform(0, 10, (n_count,)) for _ in range(snapshot_count)]
-
-    dataset = DynamicGraphStaticSignal(edge_indices, edge_weights, feature, targets)
+    dataset = StaticGraphTemporalSignal(
+        edge_indices[0], edge_weights[0], features, targets, **additional_features
+    )
 
     train_dataset, test_dataset = temporal_signal_split(dataset, 0.8)
 
@@ -654,6 +640,8 @@ def test_discrete_train_test_split_dynamic():
             assert snapshot.edge_index.shape[1] == snapshot.edge_attr.shape[0]
             assert snapshot.x.shape == (100, 32)
             assert snapshot.y.shape == (100,)
+            assert getattr(snapshot, "optional1").shape == (100, 32)
+            assert getattr(snapshot, "optional2").shape == (100, 32)
 
     for epoch in range(2):
         for snapshot in train_dataset:
@@ -661,3 +649,44 @@ def test_discrete_train_test_split_dynamic():
             assert snapshot.edge_index.shape[1] == snapshot.edge_attr.shape[0]
             assert snapshot.x.shape == (100, 32)
             assert snapshot.y.shape == (100,)
+            assert getattr(snapshot, "optional1").shape == (100, 32)
+            assert getattr(snapshot, "optional2").shape == (100, 32)
+
+
+def test_discrete_train_test_split_dynamic():
+
+    snapshot_count = 250
+    n_count = 100
+    feature_count = 32
+
+    edge_indices, edge_weights, features, additional_features = generate_signal(
+        250, 100, 32, ["optional1", "optional2"]
+    )
+
+    feature = features[0]
+
+    targets = [np.random.uniform(0, 10, (n_count,)) for _ in range(snapshot_count)]
+
+    dataset = DynamicGraphStaticSignal(
+        edge_indices, edge_weights, feature, targets,  **additional_features
+    )
+
+    train_dataset, test_dataset = temporal_signal_split(dataset, 0.8)
+
+    for epoch in range(2):
+        for snapshot in test_dataset:
+            assert snapshot.edge_index.shape[0] == 2
+            assert snapshot.edge_index.shape[1] == snapshot.edge_attr.shape[0]
+            assert snapshot.x.shape == (100, 32)
+            assert snapshot.y.shape == (100,)
+            assert getattr(snapshot, "optional1").shape == (100, 32)
+            assert getattr(snapshot, "optional2").shape == (100, 32)
+
+    for epoch in range(2):
+        for snapshot in train_dataset:
+            assert snapshot.edge_index.shape[0] == 2
+            assert snapshot.edge_index.shape[1] == snapshot.edge_attr.shape[0]
+            assert snapshot.x.shape == (100, 32)
+            assert snapshot.y.shape == (100,)
+            assert getattr(snapshot, "optional1").shape == (100, 32)
+            assert getattr(snapshot, "optional2").shape == (100, 32)

--- a/torch_geometric_temporal/signal/train_test_split.py
+++ b/torch_geometric_temporal/signal/train_test_split.py
@@ -40,6 +40,7 @@ def temporal_signal_split(
             data_iterator.edge_weight,
             data_iterator.features[0:train_snapshots],
             data_iterator.targets[0:train_snapshots],
+            **{key: getattr(data_iterator, key)[0:train_snapshots] for key in data_iterator.additional_feature_keys}
         )
 
         test_iterator = StaticGraphTemporalSignal(
@@ -47,6 +48,7 @@ def temporal_signal_split(
             data_iterator.edge_weight,
             data_iterator.features[train_snapshots:],
             data_iterator.targets[train_snapshots:],
+            **{key: getattr(data_iterator, key)[train_snapshots:] for key in data_iterator.additional_feature_keys}
         )
 
     elif type(data_iterator) == DynamicGraphTemporalSignal:
@@ -55,6 +57,7 @@ def temporal_signal_split(
             data_iterator.edge_weights[0:train_snapshots],
             data_iterator.features[0:train_snapshots],
             data_iterator.targets[0:train_snapshots],
+            **{key: getattr(data_iterator, key)[0:train_snapshots] for key in data_iterator.additional_feature_keys}
         )
 
         test_iterator = DynamicGraphTemporalSignal(
@@ -62,6 +65,7 @@ def temporal_signal_split(
             data_iterator.edge_weights[train_snapshots:],
             data_iterator.features[train_snapshots:],
             data_iterator.targets[train_snapshots:],
+            **{key: getattr(data_iterator, key)[train_snapshots:] for key in data_iterator.additional_feature_keys}
         )
 
     elif type(data_iterator) == DynamicGraphStaticSignal:
@@ -70,6 +74,7 @@ def temporal_signal_split(
             data_iterator.edge_weights[0:train_snapshots],
             data_iterator.feature,
             data_iterator.targets[0:train_snapshots],
+            **{key: getattr(data_iterator, key)[0:train_snapshots] for key in data_iterator.additional_feature_keys}
         )
 
         test_iterator = DynamicGraphStaticSignal(
@@ -77,6 +82,7 @@ def temporal_signal_split(
             data_iterator.edge_weights[train_snapshots:],
             data_iterator.feature,
             data_iterator.targets[train_snapshots:],
+            **{key: getattr(data_iterator, key)[train_snapshots:] for key in data_iterator.additional_feature_keys}
         )
 
     if type(data_iterator) == StaticGraphTemporalSignalBatch:
@@ -86,6 +92,7 @@ def temporal_signal_split(
             data_iterator.features[0:train_snapshots],
             data_iterator.targets[0:train_snapshots],
             data_iterator.batches,
+            **{key: getattr(data_iterator, key)[0:train_snapshots] for key in data_iterator.additional_feature_keys}
         )
 
         test_iterator = StaticGraphTemporalSignalBatch(
@@ -94,6 +101,7 @@ def temporal_signal_split(
             data_iterator.features[train_snapshots:],
             data_iterator.targets[train_snapshots:],
             data_iterator.batches,
+            **{key: getattr(data_iterator, key)[train_snapshots:] for key in data_iterator.additional_feature_keys}
         )
 
     elif type(data_iterator) == DynamicGraphTemporalSignalBatch:
@@ -103,6 +111,7 @@ def temporal_signal_split(
             data_iterator.features[0:train_snapshots],
             data_iterator.targets[0:train_snapshots],
             data_iterator.batches[0:train_snapshots],
+            **{key: getattr(data_iterator, key)[0:train_snapshots] for key in data_iterator.additional_feature_keys}
         )
 
         test_iterator = DynamicGraphTemporalSignalBatch(
@@ -111,6 +120,7 @@ def temporal_signal_split(
             data_iterator.features[train_snapshots:],
             data_iterator.targets[train_snapshots:],
             data_iterator.batches[train_snapshots:],
+            **{key: getattr(data_iterator, key)[train_snapshots:] for key in data_iterator.additional_feature_keys}
         )
 
     elif type(data_iterator) == DynamicGraphStaticSignalBatch:
@@ -120,6 +130,7 @@ def temporal_signal_split(
             data_iterator.feature,
             data_iterator.targets[0:train_snapshots],
             data_iterator.batches[0:train_snapshots:],
+            **{key: getattr(data_iterator, key)[0:train_snapshots] for key in data_iterator.additional_feature_keys}
         )
 
         test_iterator = DynamicGraphStaticSignalBatch(
@@ -128,5 +139,6 @@ def temporal_signal_split(
             data_iterator.feature,
             data_iterator.targets[train_snapshots:],
             data_iterator.batches[train_snapshots:],
+            **{key: getattr(data_iterator, key)[train_snapshots:] for key in data_iterator.additional_feature_keys}            
         )
     return train_iterator, test_iterator


### PR DESCRIPTION
Hi,

This fix ensures that additional features are properly split between the train and test dataset when using `temporal_signal_split`.

I edited a couple of the tests that use `temporal_signal_split`. Do leave feedback if something needs fixing.

Thanks