### PR TITLE
Refactor __get_item__ into __getitem__

### DIFF
--- a/torch_geometric_temporal/signal/dynamic_graph_static_signal.py
+++ b/torch_geometric_temporal/signal/dynamic_graph_static_signal.py
@@ -105,7 +105,7 @@ class DynamicGraphStaticSignal(object):
     def __len__(self):
         return len(self.targets)
 
-    def __get_item__(self, time_index: int):
+    def __getitem__(self, time_index: int):
         x = self._get_feature()
         edge_index = self._get_edge_index(time_index)
         edge_weight = self._get_edge_weight(time_index)
@@ -118,7 +118,7 @@ class DynamicGraphStaticSignal(object):
 
     def __next__(self):
         if self.t < len(self.targets):
-            snapshot = self.__get_item__(self.t)
+            snapshot = self[self.t]
             self.t = self.t + 1
             return snapshot
         else:

--- a/torch_geometric_temporal/signal/dynamic_graph_static_signal_batch.py
+++ b/torch_geometric_temporal/signal/dynamic_graph_static_signal_batch.py
@@ -116,7 +116,7 @@ class DynamicGraphStaticSignalBatch(object):
         }
         return additional_features
 
-    def __get_item__(self, time_index: int):
+    def __getitem__(self, time_index: int):
         x = self._get_feature()
         edge_index = self._get_edge_index(time_index)
         edge_weight = self._get_edge_weight(time_index)
@@ -130,7 +130,7 @@ class DynamicGraphStaticSignalBatch(object):
 
     def __next__(self):
         if self.t < len(self.targets):
-            snapshot = self.__get_item__(self.t)
+            snapshot = self[self.t]
             self.t = self.t + 1
             return snapshot
         else:

--- a/torch_geometric_temporal/signal/dynamic_graph_temporal_signal.py
+++ b/torch_geometric_temporal/signal/dynamic_graph_temporal_signal.py
@@ -105,7 +105,7 @@ class DynamicGraphTemporalSignal(object):
         }
         return additional_features
 
-    def __get_item__(self, time_index):
+    def __getitem__(self, time_index):
         x = self._get_features(time_index)
         edge_index = self._get_edge_index(time_index)
         edge_weight = self._get_edge_weight(time_index)
@@ -118,7 +118,7 @@ class DynamicGraphTemporalSignal(object):
 
     def __next__(self):
         if self.t < len(self.features):
-            snapshot = self.__get_item__(self.t)
+            snapshot = self[self.t]
             self.t = self.t + 1
             return snapshot
         else:

--- a/torch_geometric_temporal/signal/dynamic_graph_temporal_signal_batch.py
+++ b/torch_geometric_temporal/signal/dynamic_graph_temporal_signal_batch.py
@@ -119,7 +119,7 @@ class DynamicGraphTemporalSignalBatch(object):
         }
         return additional_features
 
-    def __get_item__(self, time_index: int):
+    def __getitem__(self, time_index: int):
         x = self._get_feature(time_index)
         edge_index = self._get_edge_index(time_index)
         edge_weight = self._get_edge_weight(time_index)
@@ -133,7 +133,7 @@ class DynamicGraphTemporalSignalBatch(object):
 
     def __next__(self):
         if self.t < len(self.features):
-            snapshot = self.__get_item__(self.t)
+            snapshot = self[self.t]
             self.t = self.t + 1
             return snapshot
         else:

--- a/torch_geometric_temporal/signal/static_graph_temporal_signal.py
+++ b/torch_geometric_temporal/signal/static_graph_temporal_signal.py
@@ -100,7 +100,7 @@ class StaticGraphTemporalSignal(object):
         }
         return additional_features
 
-    def __get_item__(self, time_index: int):
+    def __getitem__(self, time_index: int):
         x = self._get_features(time_index)
         edge_index = self._get_edge_index()
         edge_weight = self._get_edge_weight()
@@ -113,7 +113,7 @@ class StaticGraphTemporalSignal(object):
 
     def __next__(self):
         if self.t < len(self.features):
-            snapshot = self.__get_item__(self.t)
+            snapshot = self[self.t]
             self.t = self.t + 1
             return snapshot
         else:

--- a/torch_geometric_temporal/signal/static_graph_temporal_signal_batch.py
+++ b/torch_geometric_temporal/signal/static_graph_temporal_signal_batch.py
@@ -110,7 +110,7 @@ class StaticGraphTemporalSignalBatch(object):
         }
         return additional_features
 
-    def __get_item__(self, time_index: int):
+    def __getitem__(self, time_index: int):
         x = self._get_feature(time_index)
         edge_index = self._get_edge_index()
         edge_weight = self._get_edge_weight()
@@ -124,7 +124,7 @@ class StaticGraphTemporalSignalBatch(object):
 
     def __next__(self):
         if self.t < len(self.features):
-            snapshot = self.__get_item__(self.t)
+            snapshot = self[self.t]
             self.t = self.t + 1
             return snapshot
         else:


### PR DESCRIPTION
Make datasets subscriptable.

Before:
```python
from torch_geometric_temporal.dataset import ChickenpoxDatasetLoader

loader = ChickenpoxDatasetLoader()
dataset = loader.get_dataset()
dataset[0]
>>> object is not subscriptable
```

After:
```python
dataset[0]
>>> Data(x=[20, 32], edge_index=[2, 102], edge_attr=[102], y=[20])
```