### PR TITLE
Hetero support

### DIFF
--- a/docs/source/modules/root.rst
+++ b/docs/source/modules/root.rst
@@ -124,3 +124,12 @@ Auxiliary Graph Convolutional Layers
     :members:
     :undoc-members:
     :exclude-members: bn_init, conv_init, conv_branch_init, GraphAAGCN, AAGCN
+
+
+Heterogeneous Graph Convolutional Layers
+--------------
+
+.. automodule:: torch_geometric_temporal.nn.hetero.heterogclstm
+    :members:
+    :undoc-members:
+    :exclude-members: HeteroGCLSTM

--- a/test/heterogeneous_test.py
+++ b/test/heterogeneous_test.py
@@ -1,0 +1,51 @@
+import torch
+import numpy as np
+import networkx as nx
+import torch_geometric.transforms as T
+from torch_geometric.data import HeteroData
+from torch_geometric_temporal.nn.hetero import HeteroGCLSTM
+
+
+def get_edge_array(n_count):
+    return np.array([edge for edge in nx.gnp_random_graph(n_count, 0.1).edges()]).T
+
+
+def create_hetero_mock_data(n_count, feature_dict):
+    _x_dict = {'author': torch.FloatTensor(np.random.uniform(0, 1, (n_count, feature_dict['author']))),
+               'paper': torch.FloatTensor(np.random.uniform(0, 1, (n_count, feature_dict['paper'])))}
+    _edge_index_dict = {('author', 'writes', 'paper'): torch.LongTensor(get_edge_array(n_count))}
+
+    data = HeteroData()
+    data['author'].x = _x_dict['author']
+    data['paper'].x = _x_dict['paper']
+    data[('author', 'writes', 'paper')].edge_index = _edge_index_dict[('author', 'writes', 'paper')]
+    data = T.ToUndirected()(data)
+
+    return data.x_dict, data.edge_index_dict, data.metadata()
+
+
+def test_hetero_gclstm_layer():
+    """
+        Testing the HeteroGCLSTM Layer.
+    """
+    number_of_nodes = 50
+    feature_dict = {'author': 20, 'paper': 30}
+    out_channels = 32
+
+    x_dict, edge_index_dict, metadata = create_hetero_mock_data(number_of_nodes, feature_dict)
+
+    layer = HeteroGCLSTM(in_channels_dict=feature_dict, out_channels=out_channels, metadata=metadata)
+
+    h_dict, c_dict = layer(x_dict, edge_index_dict)
+
+    assert h_dict['author'].shape == (number_of_nodes, out_channels)
+    assert h_dict['paper'].shape == (number_of_nodes, out_channels)
+    assert c_dict['author'].shape == (number_of_nodes, out_channels)
+    assert c_dict['paper'].shape == (number_of_nodes, out_channels)
+
+    h_dict, c_dict = layer(x_dict, edge_index_dict, h_dict, c_dict)
+
+    assert h_dict['author'].shape == (number_of_nodes, out_channels)
+    assert h_dict['paper'].shape == (number_of_nodes, out_channels)
+    assert c_dict['author'].shape == (number_of_nodes, out_channels)
+    assert c_dict['paper'].shape == (number_of_nodes, out_channels)

--- a/torch_geometric_temporal/nn/__init__.py
+++ b/torch_geometric_temporal/nn/__init__.py
@@ -1,2 +1,3 @@
 from .recurrent import *
 from .attention import *
+from .hetero import *

--- a/torch_geometric_temporal/nn/hetero/__init__.py
+++ b/torch_geometric_temporal/nn/hetero/__init__.py
@@ -1,0 +1,1 @@
+from .heterogclstm import HeteroGCLSTM

--- a/torch_geometric_temporal/nn/hetero/heterogclstm.py
+++ b/torch_geometric_temporal/nn/hetero/heterogclstm.py
@@ -1,0 +1,179 @@
+import torch
+from torch.nn import Parameter
+from torch_geometric.nn import HeteroConv, SAGEConv
+from torch_geometric.nn.inits import glorot
+
+
+class HeteroGCLSTM(torch.nn.Module):
+    r"""An implementation similar to the Integrated Graph Convolutional Long Short Term
+        Memory Cell for heterogeneous Graphs.
+
+        Args:
+            in_channels_dict (dict of keys=str and values=int): Dimension of each node's input features.
+            out_channels (int): Number of output features.
+            metadata (tuple): Metadata on node types and edge types in the graphs. Can be generated via PyG method
+                :obj:`snapshot.metadata()` where snapshot is a single HeteroData object.
+            bias (bool, optional): If set to :obj:`False`, the layer will not learn
+                an additive bias. (default: :obj:`True`)
+    """
+
+    def __init__(
+            self,
+            in_channels_dict: dict,
+            out_channels: int,
+            metadata: tuple,
+            bias: bool = True
+    ):
+        super(HeteroGCLSTM, self).__init__()
+
+        self.in_channels_dict = in_channels_dict
+        self.out_channels = out_channels
+        self.metadata = metadata
+        self.bias = bias
+        self._create_parameters_and_layers()
+        self._set_parameters()
+
+    def _create_input_gate_parameters_and_layers(self):
+        self.conv_i = HeteroConv({edge_type: SAGEConv(in_channels=(-1, -1),
+                                                      out_channels=self.out_channels,
+                                                      bias=self.bias) for edge_type in self.metadata[1]})
+
+        self.W_i = {node_type: Parameter(torch.Tensor(in_channels, self.out_channels))
+                    for node_type, in_channels in self.in_channels_dict.items()}
+        self.b_i = {node_type: Parameter(torch.Tensor(1, self.out_channels))
+                    for node_type in self.in_channels_dict}
+
+    def _create_forget_gate_parameters_and_layers(self):
+        self.conv_f = HeteroConv({edge_type: SAGEConv(in_channels=(-1, -1),
+                                                      out_channels=self.out_channels,
+                                                      bias=self.bias) for edge_type in self.metadata[1]})
+
+        self.W_f = {node_type: Parameter(torch.Tensor(in_channels, self.out_channels))
+                    for node_type, in_channels in self.in_channels_dict.items()}
+        self.b_f = {node_type: Parameter(torch.Tensor(1, self.out_channels))
+                    for node_type in self.in_channels_dict}
+
+    def _create_cell_state_parameters_and_layers(self):
+        self.conv_c = HeteroConv({edge_type: SAGEConv(in_channels=(-1, -1),
+                                                      out_channels=self.out_channels,
+                                                      bias=self.bias) for edge_type in self.metadata[1]})
+
+        self.W_c = {node_type: Parameter(torch.Tensor(in_channels, self.out_channels))
+                    for node_type, in_channels in self.in_channels_dict.items()}
+        self.b_c = {node_type: Parameter(torch.Tensor(1, self.out_channels))
+                    for node_type in self.in_channels_dict}
+
+    def _create_output_gate_parameters_and_layers(self):
+        self.conv_o = HeteroConv({edge_type: SAGEConv(in_channels=(-1, -1),
+                                                      out_channels=self.out_channels,
+                                                      bias=self.bias) for edge_type in self.metadata[1]})
+
+        self.W_o = {node_type: Parameter(torch.Tensor(in_channels, self.out_channels))
+                    for node_type, in_channels in self.in_channels_dict.items()}
+        self.b_o = {node_type: Parameter(torch.Tensor(1, self.out_channels))
+                    for node_type in self.in_channels_dict}
+
+    def _create_parameters_and_layers(self):
+        self._create_input_gate_parameters_and_layers()
+        self._create_forget_gate_parameters_and_layers()
+        self._create_cell_state_parameters_and_layers()
+        self._create_output_gate_parameters_and_layers()
+
+    def _set_parameters(self):
+        for key in self.W_i:
+            glorot(self.W_i[key])
+        for key in self.W_f:
+            glorot(self.W_f[key])
+        for key in self.W_c:
+            glorot(self.W_c[key])
+        for key in self.W_o:
+            glorot(self.W_o[key])
+        for key in self.b_i:
+            glorot(self.b_i[key])
+        for key in self.b_f:
+            glorot(self.b_f[key])
+        for key in self.b_c:
+            glorot(self.b_c[key])
+        for key in self.b_o:
+            glorot(self.b_o[key])
+
+    def _set_hidden_state(self, x_dict, h_dict):
+        if h_dict is None:
+            h_dict = {node_type: torch.zeros(X.shape[0], self.out_channels) for node_type, X in x_dict.items()}
+        return h_dict
+
+    def _set_cell_state(self, x_dict, c_dict):
+        if c_dict is None:
+            c_dict = {node_type: torch.zeros(X.shape[0], self.out_channels) for node_type, X in x_dict.items()}
+        return c_dict
+
+    def _calculate_input_gate(self, x_dict, edge_index_dict, h_dict, c_dict):
+        i_dict = {node_type: torch.matmul(X, self.W_i[node_type]) for node_type, X in x_dict.items()}
+        i_dict = {node_type: I + self.conv_i(h_dict, edge_index_dict)[node_type] for node_type, I in i_dict.items()}
+        i_dict = {node_type: I + self.b_i[node_type] for node_type, I in i_dict.items()}
+        i_dict = {node_type: torch.sigmoid(I) for node_type, I in i_dict.items()}
+        return i_dict
+
+    def _calculate_forget_gate(self, x_dict, edge_index_dict, h_dict, c_dict):
+        f_dict = {node_type: torch.matmul(X, self.W_f[node_type]) for node_type, X in x_dict.items()}
+        f_dict = {node_type: F + self.conv_f(h_dict, edge_index_dict)[node_type] for node_type, F in f_dict.items()}
+        f_dict = {node_type: F + self.b_f[node_type] for node_type, F in f_dict.items()}
+        f_dict = {node_type: torch.sigmoid(F) for node_type, F in f_dict.items()}
+        return f_dict
+
+    def _calculate_cell_state(self, x_dict, edge_index_dict, h_dict, c_dict, i_dict, f_dict):
+        t_dict = {node_type: torch.matmul(X, self.W_c[node_type]) for node_type, X in x_dict.items()}
+        t_dict = {node_type: T + self.conv_c(h_dict, edge_index_dict)[node_type] for node_type, T in t_dict.items()}
+        t_dict = {node_type: T + self.b_c[node_type] for node_type, T in t_dict.items()}
+        t_dict = {node_type: torch.tanh(T) for node_type, T in t_dict.items()}
+        c_dict = {node_type: f_dict[node_type] * C * i_dict[node_type] * t_dict[node_type] for node_type, C in c_dict.items()}
+        return c_dict
+
+    def _calculate_output_gate(self, x_dict, edge_index_dict, h_dict, c_dict):
+        o_dict = {node_type: torch.matmul(X, self.W_o[node_type]) for node_type, X in x_dict.items()}
+        o_dict = {node_type: O + self.conv_o(h_dict, edge_index_dict)[node_type] for node_type, O in o_dict.items()}
+        o_dict = {node_type: O + self.b_o[node_type] for node_type, O in o_dict.items()}
+        o_dict = {node_type: torch.sigmoid(O) for node_type, O in o_dict.items()}
+        return o_dict
+
+    def _calculate_hidden_state(self, o_dict, c_dict):
+        h_dict = {node_type: o_dict[node_type] * torch.tanh(C) for node_type, C in c_dict.items()}
+        return h_dict
+
+    def forward(
+        self,
+        x_dict,
+        edge_index_dict,
+        h_dict=None,
+        c_dict=None,
+    ):
+        """
+        Making a forward pass. If the hidden state and cell state
+        matrix dicts are not present when the forward pass is called these are
+        initialized with zeros.
+
+        Arg types:
+            * **x_dict** *(Dictionary where keys=Strings and values=PyTorch Float Tensors)* - Node features dicts. Can
+                be obtained via PyG method :obj:`snapshot.x_dict` where snapshot is a single HeteroData object.
+            * **edge_index_dict** *(Dictionary where keys=Tuples and values=PyTorch Long Tensors)* - Graph edge type
+                and index dicts. Can be obtained via PyG method :obj:`snapshot.edge_index_dict`.
+            * **h_dict** *(Dictionary where keys=Strings and values=PyTorch Float Tensor, optional)* - Node type and
+                hidden state matrix dict for all nodes.
+            * **c_dict** *(Dictionary where keys=Strings and values=PyTorch Float Tensor, optional)* - Node type and
+                cell state matrix dict for all nodes.
+
+        Return types:
+            * **h_dict** *(Dictionary where keys=Strings and values=PyTorch Float Tensor)* - Node type and
+                hidden state matrix dict for all nodes.
+            * **c_dict** *(Dictionary where keys=Strings and values=PyTorch Float Tensor)* - Node type and
+                cell state matrix dict for all nodes.
+        """
+
+        h_dict = self._set_hidden_state(x_dict, h_dict)
+        c_dict = self._set_cell_state(x_dict, c_dict)
+        i_dict = self._calculate_input_gate(x_dict, edge_index_dict, h_dict, c_dict)
+        f_dict = self._calculate_forget_gate(x_dict, edge_index_dict, h_dict, c_dict)
+        c_dict = self._calculate_cell_state(x_dict, edge_index_dict, h_dict, c_dict, i_dict, f_dict)
+        o_dict = self._calculate_output_gate(x_dict, edge_index_dict, h_dict, c_dict)
+        h_dict = self._calculate_hidden_state(o_dict, c_dict)
+        return h_dict, c_dict


### PR DESCRIPTION
- Added new layer that can handle temporal heterogeneous graphs: `HeteroGCLSTM` that works similar as `GCLSTM`
- Test for new layer
- Documentation for new layer

I couldn't find any literature on layers for temporal graph machine learning for heterogeneous graphs. The intention is to model dictionaries for all node types (keys) with hidden/cell state matrices (values) instead of a single matrix as it is the case for homogeneous graphs. As PyG's `ChebConv` is not compatible with `HeteroData` objects I changed it with `SAGEConv` (had a talk with mathematicians working on Graph ML at our university and they think that shouldn't make too much of a difference). This layer works for the new heterogeneous data structure for now and could be improved in the future.
Are you okay with that @benedekrozemberczki ?