### PR TITLE
Make tqdm an optional dependency

### DIFF
--- a/examples/recurrent/a3tgcn_example.py
+++ b/examples/recurrent/a3tgcn_example.py
@@ -1,4 +1,8 @@
-from tqdm import tqdm
+try:
+    from tqdm import tqdm
+except ImportError:
+    def tqdm(iterable):
+        return iterable
 
 import torch
 import torch.nn.functional as F

--- a/examples/recurrent/agcrn_example.py
+++ b/examples/recurrent/agcrn_example.py
@@ -1,4 +1,8 @@
-from tqdm import tqdm
+try:
+    from tqdm import tqdm
+except ImportError:
+    def tqdm(iterable):
+        return iterable
 
 import torch
 import torch.nn.functional as F

--- a/examples/recurrent/dcrnn_example.py
+++ b/examples/recurrent/dcrnn_example.py
@@ -1,4 +1,8 @@
-from tqdm import tqdm
+try:
+    from tqdm import tqdm
+except ImportError:
+    def tqdm(iterable):
+        return iterable
 
 import torch
 import torch.nn.functional as F

--- a/examples/recurrent/dygrencoder_example.py
+++ b/examples/recurrent/dygrencoder_example.py
@@ -1,4 +1,8 @@
-from tqdm import tqdm
+try:
+    from tqdm import tqdm
+except ImportError:
+    def tqdm(iterable):
+        return iterable
 
 import torch
 import torch.nn.functional as F

--- a/examples/recurrent/evolvegcnh_example.py
+++ b/examples/recurrent/evolvegcnh_example.py
@@ -1,4 +1,8 @@
-from tqdm import tqdm
+try:
+    from tqdm import tqdm
+except ImportError:
+    def tqdm(iterable):
+        return iterable
 
 import torch
 import torch.nn.functional as F

--- a/examples/recurrent/evolvegcno_example.py
+++ b/examples/recurrent/evolvegcno_example.py
@@ -1,4 +1,8 @@
-from tqdm import tqdm
+try:
+    from tqdm import tqdm
+except ImportError:
+    def tqdm(iterable):
+        return iterable
 
 import torch
 import torch.nn.functional as F

--- a/examples/recurrent/gclstm_example.py
+++ b/examples/recurrent/gclstm_example.py
@@ -1,4 +1,8 @@
-from tqdm import tqdm
+try:
+    from tqdm import tqdm
+except ImportError:
+    def tqdm(iterable):
+        return iterable
 
 import torch
 import torch.nn.functional as F

--- a/examples/recurrent/gconvgru_example.py
+++ b/examples/recurrent/gconvgru_example.py
@@ -1,4 +1,8 @@
-from tqdm import tqdm
+try:
+    from tqdm import tqdm
+except ImportError:
+    def tqdm(iterable):
+        return iterable
 
 import torch
 import torch.nn.functional as F

--- a/examples/recurrent/gconvlstm_example.py
+++ b/examples/recurrent/gconvlstm_example.py
@@ -1,4 +1,8 @@
-from tqdm import tqdm
+try:
+    from tqdm import tqdm
+except ImportError:
+    def tqdm(iterable):
+        return iterable
 
 import torch
 import torch.nn.functional as F

--- a/examples/recurrent/lrgcn_example.py
+++ b/examples/recurrent/lrgcn_example.py
@@ -1,4 +1,8 @@
-from tqdm import tqdm
+try:
+    from tqdm import tqdm
+except ImportError:
+    def tqdm(iterable):
+        return iterable
 
 import torch
 import torch.nn.functional as F

--- a/examples/recurrent/mpnnlstm_example.py
+++ b/examples/recurrent/mpnnlstm_example.py
@@ -1,4 +1,8 @@
-from tqdm import tqdm
+try:
+    from tqdm import tqdm
+except ImportError:
+    def tqdm(iterable):
+        return iterable
 
 import torch
 import torch.nn.functional as F

--- a/examples/recurrent/tgcn_example.py
+++ b/examples/recurrent/tgcn_example.py
@@ -1,4 +1,8 @@
-from tqdm import tqdm
+try:
+    from tqdm import tqdm
+except ImportError:
+    def tqdm(iterable):
+        return iterable
 
 import torch
 import torch.nn.functional as F

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ install_requires = [
     "six",
     "networkx",
 ]
-tests_require = ["pytest", "pytest-cov", "mock", "tqdm"]
+tests_require = ["pytest", "pytest-cov", "mock", "networkx", "tqdm"]
 
 keywords = [
     "machine-learning",

--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,10 @@ install_requires = [
     "torch_geometric",
     "numpy",
     "scipy",
-    "tqdm",
     "six",
     "networkx",
 ]
-tests_require = ["pytest", "pytest-cov", "mock", "networkx"]
+tests_require = ["pytest", "pytest-cov", "mock", "tqdm"]
 
 keywords = [
     "machine-learning",


### PR DESCRIPTION
tqdm is only used in the examples. Better to avoid including it as a mandatory dependency in "install_requires".