### PR TITLE
Remove scipy from mandatory dependencies (not used)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 jobs:
     build:
       runs-on: ${{ matrix.os }}
-
+        
       strategy:
         matrix:
           os: [ubuntu-20.04]

--- a/notebooks/astgcn_for_traffic_flow_forecasting.ipynb
+++ b/notebooks/astgcn_for_traffic_flow_forecasting.ipynb
@@ -105,7 +105,6 @@
     "import torch.nn as nn\n",
     "import torch.optim as optim\n",
     "import torch.nn.functional as F\n",
-    "from scipy.sparse.linalg import eigs\n",
     "\n",
     "\n",
     "USE_CUDA = torch.cuda.is_available()\n",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ install_requires = [
     "torch_sparse",
     "torch_geometric",
     "numpy",
-    "scipy",
     "six",
     "networkx",
 ]


### PR DESCRIPTION
Only reference to scipy was in one notebook, but that reference wasn't actually used.