### PR TITLE
Update installation instructions for PyTorch 1.11.0 and PyG latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       - run: which python
       - name: Install main dependencies
         run: |
-         python -m pip install pytorch==1.11.0 torchvision==0.12.0 torchaudio==0.11.0
+         python -m pip install torch==1.11.0
          python -m pip install torch-scatter torch-sparse torch-cluster torch-geometric -f https://data.pyg.org/whl/torch-1.11.0+cpu.html
          python -m pip install sphinx sphinx_rtd_theme
       - name: Install main package

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,18 +1,16 @@
 name: CI
 
 on:
-
   push:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-
   workflow_dispatch:
 
 jobs:
     build:
       runs-on: ${{ matrix.os }}
-        
+
       strategy:
         matrix:
           os: [ubuntu-18.04]
@@ -30,11 +28,8 @@ jobs:
       - run: which python
       - name: Install main dependencies
         run: |
-         conda install -y scipy
-         python -m pip install torch==1.10.1+cpu torchvision==0.11.2+cpu torchaudio==0.10.1+cpu -f https://download.pytorch.org/whl/cpu/torch_stable.html
-         python -m pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
-         python -m pip install torch-sparse -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
-         python -m pip install torch-geometric
+         python -m pip install pytorch==1.11.0 torchvision==0.12.0 torchaudio==0.11.0
+         python -m pip install torch-scatter torch-sparse torch-cluster torch-geometric -f https://data.pyg.org/whl/torch-1.11.0+cpu.html
          python -m pip install sphinx sphinx_rtd_theme
       - name: Install main package
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
 
       strategy:
         matrix:
-          os: [ubuntu-18.04]
+          os: [ubuntu-20.04]
 
       steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -163,26 +163,15 @@ If you notice anything unexpected, please open an [issue](https://benedekrozembe
 
 **Installation**
 
-Binaries are provided for Python version <= 3.9.
-
-**PyTorch 1.10.0**
-
-To install the binaries for PyTorch 1.10.0, simply run
+First install [pytorch][pytorch-install] and [pytorch-geometric][pyg-install]
+and then run
 
 ```sh
-pip install torch-scatter -f https://data.pyg.org/whl/torch-1.10.0+${CUDA}.html
-pip install torch-sparse -f https://data.pyg.org/whl/torch-1.10.0+${CUDA}.html
-pip install torch-geometric
 pip install torch-geometric-temporal
 ```
 
-where `${CUDA}` should be replaced by either `cpu`, `cu102`, or `cu113` depending on your PyTorch installation.
-
-|             | `cpu` | `cu102` | `cu113` |
-|-------------|-------|---------|---------|
-| **Linux**   | ✅    | ✅      | ✅      |
-| **Windows** | ✅    | ✅      | ✅      |
-| **macOS**   | ✅    |         |         |
+[pytorch-install]: https://pytorch.org/get-started/locally/
+[pyg-install]: https://pytorch-geometric.readthedocs.io/en/latest/notes/installation.html
 
 --------------------------------------------------------------------------------
 

--- a/docs/source/notes/installation.rst
+++ b/docs/source/notes/installation.rst
@@ -2,21 +2,12 @@ Installation
 ============
 
 The installation of PyTorch Geometric Temporal requires the presence of certain prerequisites. These are described in great detail in the installation description of PyTorch Geometric. Please follow the instructions laid out `here <https://pytorch-geometric.readthedocs.io/en/latest/notes/installation.html>`_. You might also take a look at the `readme file <https://github.com/benedekrozemberczki/pytorch_geometric_temporal>`_ of the PyTorch Geometric Temporal repository.
-Binaries are provided for Python version <= 3.9.
 
-**PyTorch 1.10.0**
-
-To install the binaries for PyTorch 1.10.0, simply run
+Once the required versions of PyTorch and PyTorch Geometric are installed, simply run:
 
     .. code-block:: none
 
-        $ pip install torch-scatter -f https://pytorch-geometric.com/whl/torch-1.10.0+${CUDA}.html
-        $ pip install torch-sparse -f https://pytorch-geometric.com/whl/torch-1.10.0+${CUDA}.html
-        $ pip install torch-geometric
         $ pip install torch-geometric-temporal
-
-
-where `${CUDA}` should be replaced by either `cpu`, `cu102`, or `cu113` depending on your PyTorch installation.
 
 **Updating the Library**
 


### PR DESCRIPTION
All of the "difficult" dependencies of torch-geometric-temporal are also dependencies of torch-geometric, so once torch-geometric is installed, torch-geometric-temporal is a simple pip install.

Updated instruction for PyTorch 1.11.0, since PyTorch 1.12.0 related binaries are not available on every platform and installation method.