### PR TITLE
Corrected implementation of tgcn example

### DIFF
--- a/examples/recurrent/tgcn_example.py
+++ b/examples/recurrent/tgcn_example.py
@@ -23,11 +23,11 @@ class RecurrentGCN(torch.nn.Module):
         self.recurrent = TGCN(node_features, 32)
         self.linear = torch.nn.Linear(32, 1)
 
-    def forward(self, x, edge_index, edge_weight):
-        h = self.recurrent(x, edge_index, edge_weight)
-        h = F.relu(h)
-        h = self.linear(h)
-        return h
+    def forward(self, x, edge_index, edge_weight, prev_hidden_state):
+        h = self.recurrent(x, edge_index, edge_weight, prev_hidden_state)
+        y = F.relu(h)
+        y = self.linear(y)
+        return y, h
         
 model = RecurrentGCN(node_features = 4)
 
@@ -37,8 +37,9 @@ model.train()
 
 for epoch in tqdm(range(50)):
     cost = 0
+    hidden_state = None
     for time, snapshot in enumerate(train_dataset):
-        y_hat = model(snapshot.x, snapshot.edge_index, snapshot.edge_attr)
+        y_hat, hidden_state = model(snapshot.x, snapshot.edge_index, snapshot.edge_attr,hidden_state)
         cost = cost + torch.mean((y_hat-snapshot.y)**2)
     cost = cost / (time+1)
     cost.backward()
@@ -47,8 +48,9 @@ for epoch in tqdm(range(50)):
     
 model.eval()
 cost = 0
+hidden_state = None
 for time, snapshot in enumerate(test_dataset):
-    y_hat = model(snapshot.x, snapshot.edge_index, snapshot.edge_attr)
+    y_hat, hidden_state = model(snapshot.x, snapshot.edge_index, snapshot.edge_attr, hidden_state)
     cost = cost + torch.mean((y_hat-snapshot.y)**2)
 cost = cost / (time+1)
 cost = cost.item()


### PR DESCRIPTION
Corrected the tgcn_example code to allow previous hidden states to passed for every timestamp. Changes were made in the RecurrentGCN model definition to allow prev_hidden_state to be passed as argument. The RecurrentGCN forward function was updated to return both the hidden state and the output. Changes were made in the training and evaluating portions to pass the previous hidden state as input when the model is called. 