### PR TITLE
Generalize type hints in signal/dataset classes to explicitly support custom collections

### DIFF
--- a/torch_geometric_temporal/signal/dynamic_graph_static_signal.py
+++ b/torch_geometric_temporal/signal/dynamic_graph_static_signal.py
@@ -1,14 +1,14 @@
 import torch
 import numpy as np
-from typing import List, Union
+from typing import Sequence, Union
 from torch_geometric.data import Data
 
 
-Edge_Indices = List[Union[np.ndarray, None]]
-Edge_Weights = List[Union[np.ndarray, None]]
+Edge_Indices = Sequence[Union[np.ndarray, None]]
+Edge_Weights = Sequence[Union[np.ndarray, None]]
 Node_Feature = Union[np.ndarray, None]
-Targets = List[Union[np.ndarray, None]]
-Additional_Features = List[np.ndarray]
+Targets = Sequence[Union[np.ndarray, None]]
+Additional_Features = Sequence[np.ndarray]
 
 
 class DynamicGraphStaticSignal(object):
@@ -20,11 +20,11 @@ class DynamicGraphStaticSignal(object):
     edge weights, target matrices and optionally passed attributes might change.
 
     Args:
-        edge_indices (List of Numpy arrays): List of edge index tensors.
-        edge_weights (List of Numpy arrays): List of edge weight tensors.
+        edge_indices (Sequence of Numpy arrays): Sequence of edge index tensors.
+        edge_weights (Sequence of Numpy arrays): Sequence of edge weight tensors.
         feature (Numpy array): Node feature tensor.
-        targets (List of Numpy arrays): List of node label (target) tensors.
-        **kwargs (optional List of Numpy arrays): List of additional attributes.
+        targets (Sequence of Numpy arrays): Sequence of node label (target) tensors.
+        **kwargs (optional Sequence of Numpy arrays): Sequence of additional attributes.
     """
 
     def __init__(

--- a/torch_geometric_temporal/signal/dynamic_graph_static_signal_batch.py
+++ b/torch_geometric_temporal/signal/dynamic_graph_static_signal_batch.py
@@ -1,15 +1,15 @@
 import torch
 import numpy as np
-from typing import List, Union
+from typing import Sequence, Union
 from torch_geometric.data import Batch
 
 
-Edge_Indices = List[Union[np.ndarray, None]]
-Edge_Weights = List[Union[np.ndarray, None]]
+Edge_Indices = Sequence[Union[np.ndarray, None]]
+Edge_Weights = Sequence[Union[np.ndarray, None]]
 Node_Feature = Union[np.ndarray, None]
-Targets = List[Union[np.ndarray, None]]
-Batches = List[Union[np.ndarray, None]]
-Additional_Features = List[np.ndarray]
+Targets = Sequence[Union[np.ndarray, None]]
+Batches = Sequence[Union[np.ndarray, None]]
+Additional_Features = Sequence[np.ndarray]
 
 
 class DynamicGraphStaticSignalBatch(object):
@@ -22,12 +22,12 @@ class DynamicGraphStaticSignalBatch(object):
     attributes might change.
 
     Args:
-        edge_indices (List of Numpy arrays): List of edge index tensors.
-        edge_weights (List of Numpy arrays): List of edge weight tensors.
+        edge_indices (Sequence of Numpy arrays): Sequence of edge index tensors.
+        edge_weights (Sequence of Numpy arrays): Sequence of edge weight tensors.
         feature (Numpy array): Node feature tensor.
-        targets (List of Numpy arrays): List of node label (target) tensors.
-        batches (List of Numpy arrays): List of batch index tensors.
-        **kwargs (optional List of Numpy arrays): List of additional attributes.
+        targets (Sequence of Numpy arrays): Sequence of node label (target) tensors.
+        batches (Sequence of Numpy arrays): Sequence of batch index tensors.
+        **kwargs (optional Sequence of Numpy arrays): Sequence of additional attributes.
     """
 
     def __init__(

--- a/torch_geometric_temporal/signal/dynamic_graph_temporal_signal.py
+++ b/torch_geometric_temporal/signal/dynamic_graph_temporal_signal.py
@@ -1,14 +1,14 @@
 import torch
 import numpy as np
-from typing import List, Union
+from typing import Sequence, Union
 from torch_geometric.data import Data
 
 
-Edge_Indices = List[Union[np.ndarray, None]]
-Edge_Weights = List[Union[np.ndarray, None]]
-Node_Features = List[Union[np.ndarray, None]]
-Targets = List[Union[np.ndarray, None]]
-Additional_Features = List[np.ndarray]
+Edge_Indices = Sequence[Union[np.ndarray, None]]
+Edge_Weights = Sequence[Union[np.ndarray, None]]
+Node_Features = Sequence[Union[np.ndarray, None]]
+Targets = Sequence[Union[np.ndarray, None]]
+Additional_Features = Sequence[np.ndarray]
 
 
 class DynamicGraphTemporalSignal(object):
@@ -20,11 +20,11 @@ class DynamicGraphTemporalSignal(object):
     edge weights, target matrices and optionally passed attributes might change.
 
     Args:
-        edge_indices (List of Numpy arrays): List of edge index tensors.
-        edge_weights (List of Numpy arrays): List of edge weight tensors.
-        features (List of Numpy arrays): List of node feature tensors.
-        targets (List of Numpy arrays): List of node label (target) tensors.
-        **kwargs (optional List of Numpy arrays): List of additional attributes.
+        edge_indices (Sequence of Numpy arrays): Sequence of edge index tensors.
+        edge_weights (Sequence of Numpy arrays): Sequence of edge weight tensors.
+        features (Sequence of Numpy arrays): Sequence of node feature tensors.
+        targets (Sequence of Numpy arrays): Sequence of node label (target) tensors.
+        **kwargs (optional Sequence of Numpy arrays): Sequence of additional attributes.
     """
 
     def __init__(

--- a/torch_geometric_temporal/signal/dynamic_graph_temporal_signal_batch.py
+++ b/torch_geometric_temporal/signal/dynamic_graph_temporal_signal_batch.py
@@ -1,15 +1,15 @@
 import torch
 import numpy as np
-from typing import List, Union
+from typing import Sequence, Union
 from torch_geometric.data import Batch
 
 
-Edge_Indices = List[Union[np.ndarray, None]]
-Edge_Weights = List[Union[np.ndarray, None]]
-Node_Features = List[Union[np.ndarray, None]]
-Targets = List[Union[np.ndarray, None]]
-Batches = List[Union[np.ndarray, None]]
-Additional_Features = List[np.ndarray]
+Edge_Indices = Sequence[Union[np.ndarray, None]]
+Edge_Weights = Sequence[Union[np.ndarray, None]]
+Node_Features = Sequence[Union[np.ndarray, None]]
+Targets = Sequence[Union[np.ndarray, None]]
+Batches = Sequence[Union[np.ndarray, None]]
+Additional_Features = Sequence[np.ndarray]
 
 
 class DynamicGraphTemporalSignalBatch(object):
@@ -22,12 +22,12 @@ class DynamicGraphTemporalSignalBatch(object):
     attributes might change.
 
     Args:
-        edge_indices (List of Numpy arrays): List of edge index tensors.
-        edge_weights (List of Numpy arrays): List of edge weight tensors.
-        features (List of Numpy arrays): List of node feature tensors.
-        targets (List of Numpy arrays): List of node label (target) tensors.
-        batches (List of Numpy arrays): List of batch index tensors.
-        **kwargs (optional List of Numpy arrays): List of additional attributes.
+        edge_indices (Sequence of Numpy arrays): Sequence of edge index tensors.
+        edge_weights (Sequence of Numpy arrays): Sequence of edge weight tensors.
+        features (Sequence of Numpy arrays): Sequence of node feature tensors.
+        targets (Sequence of Numpy arrays): Sequence of node label (target) tensors.
+        batches (Sequence of Numpy arrays): Sequence of batch index tensors.
+        **kwargs (optional Sequence of Numpy arrays): Sequence of additional attributes.
     """
 
     def __init__(

--- a/torch_geometric_temporal/signal/dynamic_hetero_graph_static_signal.py
+++ b/torch_geometric_temporal/signal/dynamic_hetero_graph_static_signal.py
@@ -1,14 +1,14 @@
 import torch
 import numpy as np
-from typing import List, Dict, Union, Tuple
+from typing import Sequence, Dict, Union, Tuple
 from torch_geometric.data import HeteroData
 
 
-Edge_Indices = List[Union[Dict[Tuple[str, str, str], np.ndarray], None]]
-Edge_Weights = List[Union[Dict[Tuple[str, str, str], np.ndarray], None]]
+Edge_Indices = Sequence[Union[Dict[Tuple[str, str, str], np.ndarray], None]]
+Edge_Weights = Sequence[Union[Dict[Tuple[str, str, str], np.ndarray], None]]
 Node_Feature = Union[Dict[str, np.ndarray], None]
-Targets = List[Union[Dict[str, np.ndarray], None]]
-Additional_Features = List[Union[Dict[str, np.ndarray], None]]
+Targets = Sequence[Union[Dict[str, np.ndarray], None]]
+Additional_Features = Sequence[Union[Dict[str, np.ndarray], None]]
 
 
 class DynamicHeteroGraphStaticSignal(object):
@@ -20,15 +20,15 @@ class DynamicHeteroGraphStaticSignal(object):
     edge weights, target matrices and optionally passed attributes might change.
 
     Args:
-        edge_index_dicts (List of dictionaries where keys=Tuples and values=Numpy arrays):
-         List of relation type tuples and their edge index tensors.
-        edge_weight_dicts (List of dictionaries where keys=Tuples and values=Numpy arrays):
-         List of relation type tuples and their edge weight tensors.
+        edge_index_dicts (Sequence of dictionaries where keys=Tuples and values=Numpy arrays):
+         Sequence of relation type tuples and their edge index tensors.
+        edge_weight_dicts (Sequence of dictionaries where keys=Tuples and values=Numpy arrays):
+         Sequence of relation type tuples and their edge weight tensors.
         feature_dict (Dictionary of keys=Strings and values=Numpy arrays): Node type tuples
          and their node feature tensor.
-        target_dicts (List of dictionaries where keys=Strings and values=Numpy arrays):
-         List of node types and their label (target) tensors.
-        **kwargs (optional List of dictionaries where keys=Strings and values=Numpy arrays): List
+        target_dicts (Sequence of dictionaries where keys=Strings and values=Numpy arrays):
+         Sequence of node types and their label (target) tensors.
+        **kwargs (optional Sequence of dictionaries where keys=Strings and values=Numpy arrays): Sequence
          of node types and their additional attributes.
     """
 

--- a/torch_geometric_temporal/signal/dynamic_hetero_graph_static_signal_batch.py
+++ b/torch_geometric_temporal/signal/dynamic_hetero_graph_static_signal_batch.py
@@ -1,15 +1,15 @@
 import torch
 import numpy as np
-from typing import List, Dict, Union, Tuple
+from typing import Sequence, Dict, Union, Tuple
 from torch_geometric.data import HeteroData, Batch
 
 
-Edge_Indices = List[Union[Dict[Tuple[str, str, str], np.ndarray], None]]
-Edge_Weights = List[Union[Dict[Tuple[str, str, str], np.ndarray], None]]
+Edge_Indices = Sequence[Union[Dict[Tuple[str, str, str], np.ndarray], None]]
+Edge_Weights = Sequence[Union[Dict[Tuple[str, str, str], np.ndarray], None]]
 Node_Feature = Union[Dict[str, np.ndarray], None]
-Targets = List[Union[Dict[str, np.ndarray], None]]
-Batches = List[Union[Dict[str, np.ndarray], None]]
-Additional_Features = List[Union[Dict[str, np.ndarray], None]]
+Targets = Sequence[Union[Dict[str, np.ndarray], None]]
+Batches = Sequence[Union[Dict[str, np.ndarray], None]]
+Additional_Features = Sequence[Union[Dict[str, np.ndarray], None]]
 
 
 class DynamicHeteroGraphStaticSignalBatch(object):
@@ -22,17 +22,17 @@ class DynamicHeteroGraphStaticSignalBatch(object):
     attributes might change.
 
     Args:
-        edge_index_dicts (List of dictionaries where keys=Tuples and values=Numpy arrays):
-         List of relation type tuples and their edge index tensors.
-        edge_weight_dicts (List of dictionaries where keys=Tuples and values=Numpy arrays):
-         List of relation type tuples and their edge weight tensors.
+        edge_index_dicts (Sequence of dictionaries where keys=Tuples and values=Numpy arrays):
+         Sequence of relation type tuples and their edge index tensors.
+        edge_weight_dicts (Sequence of dictionaries where keys=Tuples and values=Numpy arrays):
+         Sequence of relation type tuples and their edge weight tensors.
         feature_dict (Dictionary of keys=Strings and values=Numpy arrays): Node type tuples
          and their node feature tensor.
-        target_dicts (List of dictionaries where keys=Strings and values=Numpy arrays):
-         List of node types and their label (target) tensors.
-        batch_dicts (List of dictionaries where keys=Strings and values=Numpy arrays):
-         List of batch index tensor for each node type.
-        **kwargs (optional List of dictionaries where keys=Strings and values=Numpy arrays): List
+        target_dicts (Sequence of dictionaries where keys=Strings and values=Numpy arrays):
+         Sequence of node types and their label (target) tensors.
+        batch_dicts (Sequence of dictionaries where keys=Strings and values=Numpy arrays):
+         Sequence of batch index tensor for each node type.
+        **kwargs (optional Sequence of dictionaries where keys=Strings and values=Numpy arrays): Sequence
          of node types and their additional attributes.
     """
 

--- a/torch_geometric_temporal/signal/dynamic_hetero_graph_temporal_signal.py
+++ b/torch_geometric_temporal/signal/dynamic_hetero_graph_temporal_signal.py
@@ -1,14 +1,14 @@
 import torch
 import numpy as np
-from typing import List, Dict, Union, Tuple
+from typing import Sequence, Dict, Union, Tuple
 from torch_geometric.data import HeteroData
 
 
-Edge_Indices = List[Union[Dict[Tuple[str, str, str], np.ndarray], None]]
-Edge_Weights = List[Union[Dict[Tuple[str, str, str], np.ndarray], None]]
-Node_Features = List[Union[Dict[str, np.ndarray], None]]
-Targets = List[Union[Dict[str, np.ndarray], None]]
-Additional_Features = List[Union[Dict[str, np.ndarray], None]]
+Edge_Indices = Sequence[Union[Dict[Tuple[str, str, str], np.ndarray], None]]
+Edge_Weights = Sequence[Union[Dict[Tuple[str, str, str], np.ndarray], None]]
+Node_Features = Sequence[Union[Dict[str, np.ndarray], None]]
+Targets = Sequence[Union[Dict[str, np.ndarray], None]]
+Additional_Features = Sequence[Union[Dict[str, np.ndarray], None]]
 
 
 class DynamicHeteroGraphTemporalSignal(object):
@@ -20,15 +20,15 @@ class DynamicHeteroGraphTemporalSignal(object):
     edge weights, target matrices and optionally passed attributes might change.
 
     Args:
-        edge_index_dicts (List of dictionaries where keys=Tuples and values=Numpy arrays):
-         List of relation type tuples and their edge index tensors.
-        edge_weight_dicts (List of dictionaries where keys=Tuples and values=Numpy arrays):
-         List of relation type tuples and their edge weight tensors.
-        feature_dicts (List of dictionaries where keys=Strings and values=Numpy arrays): List of node
+        edge_index_dicts (Sequence of dictionaries where keys=Tuples and values=Numpy arrays):
+         Sequence of relation type tuples and their edge index tensors.
+        edge_weight_dicts (Sequence of dictionaries where keys=Tuples and values=Numpy arrays):
+         Sequence of relation type tuples and their edge weight tensors.
+        feature_dicts (Sequence of dictionaries where keys=Strings and values=Numpy arrays): Sequence of node
          types and their feature tensors.
-        target_dicts (List of dictionaries where keys=Strings and values=Numpy arrays): List of node
+        target_dicts (Sequence of dictionaries where keys=Strings and values=Numpy arrays): Sequence of node
          types and their label (target) tensors.
-        **kwargs (optional List of dictionaries where keys=Strings and values=Numpy arrays): List
+        **kwargs (optional Sequence of dictionaries where keys=Strings and values=Numpy arrays): Sequence
          of node types and their additional attributes.
     """
 

--- a/torch_geometric_temporal/signal/dynamic_hetero_graph_temporal_signal_batch.py
+++ b/torch_geometric_temporal/signal/dynamic_hetero_graph_temporal_signal_batch.py
@@ -1,15 +1,15 @@
 import torch
 import numpy as np
-from typing import List, Dict, Union, Tuple
+from typing import Sequence, Dict, Union, Tuple
 from torch_geometric.data import HeteroData, Batch
 
 
-Edge_Indices = List[Union[Dict[Tuple[str, str, str], np.ndarray], None]]
-Edge_Weights = List[Union[Dict[Tuple[str, str, str], np.ndarray], None]]
-Node_Features = List[Union[Dict[str, np.ndarray], None]]
-Targets = List[Union[Dict[str, np.ndarray], None]]
-Batches = List[Union[Dict[str, np.ndarray], None]]
-Additional_Features = List[Union[Dict[str, np.ndarray], None]]
+Edge_Indices = Sequence[Union[Dict[Tuple[str, str, str], np.ndarray], None]]
+Edge_Weights = Sequence[Union[Dict[Tuple[str, str, str], np.ndarray], None]]
+Node_Features = Sequence[Union[Dict[str, np.ndarray], None]]
+Targets = Sequence[Union[Dict[str, np.ndarray], None]]
+Batches = Sequence[Union[Dict[str, np.ndarray], None]]
+Additional_Features = Sequence[Union[Dict[str, np.ndarray], None]]
 
 
 class DynamicHeteroGraphTemporalSignalBatch(object):
@@ -22,18 +22,18 @@ class DynamicHeteroGraphTemporalSignalBatch(object):
     attributes might change.
 
     Args:
-        edge_index_dicts (List of dictionaries where keys=Tuples and values=Numpy arrays):
-         List of relation type tuples and their edge index tensors.
-        edge_weight_dicts (List of dictionaries where keys=Tuples and values=Numpy arrays):
-         List of relation type tuples and their edge weight tensors.
-        feature_dicts (List of dictionaries where keys=Strings and values=Numpy arrays):
-         List of node types and their feature tensors.
-        target_dicts (List of dictionaries where keys=Strings and values=Numpy arrays):
-         List of node types and their label (target) tensors.
-        batch_dicts (List of dictionaries where keys=Strings and values=Numpy arrays):
-         List of batch index tensor for each node type.
-        **kwargs (optional List of dictionaries where keys=Strings and values=Numpy arrays):
-         List of node types and their additional attributes.
+        edge_index_dicts (Sequence of dictionaries where keys=Tuples and values=Numpy arrays):
+         Sequence of relation type tuples and their edge index tensors.
+        edge_weight_dicts (Sequence of dictionaries where keys=Tuples and values=Numpy arrays):
+         Sequence of relation type tuples and their edge weight tensors.
+        feature_dicts (Sequence of dictionaries where keys=Strings and values=Numpy arrays):
+         Sequence of node types and their feature tensors.
+        target_dicts (Sequence of dictionaries where keys=Strings and values=Numpy arrays):
+         Sequence of node types and their label (target) tensors.
+        batch_dicts (Sequence of dictionaries where keys=Strings and values=Numpy arrays):
+         Sequence of batch index tensor for each node type.
+        **kwargs (optional Sequence of dictionaries where keys=Strings and values=Numpy arrays):
+         Sequence of node types and their additional attributes.
     """
 
     def __init__(

--- a/torch_geometric_temporal/signal/static_graph_temporal_signal.py
+++ b/torch_geometric_temporal/signal/static_graph_temporal_signal.py
@@ -1,14 +1,14 @@
 import torch
 import numpy as np
-from typing import List, Union
+from typing import Sequence, Union
 from torch_geometric.data import Data
 
 
 Edge_Index = Union[np.ndarray, None]
 Edge_Weight = Union[np.ndarray, None]
-Node_Features = List[Union[np.ndarray, None]]
-Targets = List[Union[np.ndarray, None]]
-Additional_Features = List[np.ndarray]
+Node_Features = Sequence[Union[np.ndarray, None]]
+Targets = Sequence[Union[np.ndarray, None]]
+Additional_Features = Sequence[np.ndarray]
 
 
 class StaticGraphTemporalSignal(object):
@@ -23,9 +23,9 @@ class StaticGraphTemporalSignal(object):
     Args:
         edge_index (Numpy array): Index tensor of edges.
         edge_weight (Numpy array): Edge weight tensor.
-        features (List of Numpy arrays): List of node feature tensors.
-        targets (List of Numpy arrays): List of node label (target) tensors.
-        **kwargs (optional List of Numpy arrays): List of additional attributes.
+        features (Sequence of Numpy arrays): Sequence of node feature tensors.
+        targets (Sequence of Numpy arrays): Sequence of node label (target) tensors.
+        **kwargs (optional Sequence of Numpy arrays): Sequence of additional attributes.
     """
 
     def __init__(

--- a/torch_geometric_temporal/signal/static_graph_temporal_signal_batch.py
+++ b/torch_geometric_temporal/signal/static_graph_temporal_signal_batch.py
@@ -1,15 +1,15 @@
 import torch
 import numpy as np
-from typing import List, Union
+from typing import Sequence, Union
 from torch_geometric.data import Batch
 
 
 Edge_Index = Union[np.ndarray, None]
 Edge_Weight = Union[np.ndarray, None]
-Node_Features = List[Union[np.ndarray, None]]
-Targets = List[Union[np.ndarray, None]]
+Node_Features = Sequence[Union[np.ndarray, None]]
+Targets = Sequence[Union[np.ndarray, None]]
 Batches = Union[np.ndarray, None]
-Additional_Features = List[np.ndarray]
+Additional_Features = Sequence[np.ndarray]
 
 
 class StaticGraphTemporalSignalBatch(object):
@@ -24,10 +24,10 @@ class StaticGraphTemporalSignalBatch(object):
     Args:
         edge_index (Numpy array): Index tensor of edges.
         edge_weight (Numpy array): Edge weight tensor.
-        features (List of Numpy arrays): List of node feature tensors.
-        targets (List of Numpy arrays): List of node label (target) tensors.
+        features (Sequence of Numpy arrays): Sequence of node feature tensors.
+        targets (Sequence of Numpy arrays): Sequence of node label (target) tensors.
         batches (Numpy array): Batch index tensor.
-        **kwargs (optional List of Numpy arrays): List of additional attributes.
+        **kwargs (optional Sequence of Numpy arrays): Sequence of additional attributes.
     """
 
     def __init__(

--- a/torch_geometric_temporal/signal/static_hetero_graph_temporal_signal.py
+++ b/torch_geometric_temporal/signal/static_hetero_graph_temporal_signal.py
@@ -1,14 +1,14 @@
 import torch
 import numpy as np
-from typing import List, Dict, Union, Tuple
+from typing import Sequence, Dict, Union, Tuple
 from torch_geometric.data import HeteroData
 
 
 Edge_Index = Union[Dict[Tuple[str, str, str], np.ndarray], None]
 Edge_Weight = Union[Dict[Tuple[str, str, str], np.ndarray], None]
-Node_Features = List[Union[Dict[str, np.ndarray], None]]
-Targets = List[Union[Dict[str, np.ndarray], None]]
-Additional_Features = List[Union[Dict[str, np.ndarray], None]]
+Node_Features = Sequence[Union[Dict[str, np.ndarray], None]]
+Targets = Sequence[Union[Dict[str, np.ndarray], None]]
+Additional_Features = Sequence[Union[Dict[str, np.ndarray], None]]
 
 
 class StaticHeteroGraphTemporalSignal(object):
@@ -80,11 +80,11 @@ class StaticHeteroGraphTemporalSignal(object):
          and their edge index tensors.
         edge_weight_dict (Dictionary of keys=Tuples and values=Numpy arrays): Relation type tuples
          and their edge weight tensors.
-        feature_dicts (List of dictionaries where keys=Strings and values=Numpy arrays): List of node
+        feature_dicts (Sequence of dictionaries where keys=Strings and values=Numpy arrays): Sequence of node
          types and their feature tensors.
-        target_dicts (List of dictionaries where keys=Strings and values=Numpy arrays): List of node
+        target_dicts (Sequence of dictionaries where keys=Strings and values=Numpy arrays): Sequence of node
          types and their label (target) tensors.
-        **kwargs (optional List of dictionaries where keys=Strings and values=Numpy arrays): List
+        **kwargs (optional Sequence of dictionaries where keys=Strings and values=Numpy arrays): Sequence
          of node types and their additional attributes.
     """
 

--- a/torch_geometric_temporal/signal/static_hetero_graph_temporal_signal_batch.py
+++ b/torch_geometric_temporal/signal/static_hetero_graph_temporal_signal_batch.py
@@ -1,14 +1,14 @@
 import torch
 import numpy as np
-from typing import List, Dict, Union, Tuple
+from typing import Sequence, Dict, Union, Tuple
 from torch_geometric.data import Batch, HeteroData
 
 Edge_Index = Union[Dict[Tuple[str, str, str], np.ndarray], None]
 Edge_Weight = Union[Dict[Tuple[str, str, str], np.ndarray], None]
-Node_Features = List[Union[Dict[str, np.ndarray], None]]
-Targets = List[Union[Dict[str, np.ndarray], None]]
+Node_Features = Sequence[Union[Dict[str, np.ndarray], None]]
+Targets = Sequence[Union[Dict[str, np.ndarray], None]]
 Batches = Union[Dict[str, np.ndarray], None]
-Additional_Features = List[Union[Dict[str, np.ndarray], None]]
+Additional_Features = Sequence[Union[Dict[str, np.ndarray], None]]
 
 
 class StaticHeteroGraphTemporalSignalBatch(object):
@@ -25,13 +25,13 @@ class StaticHeteroGraphTemporalSignalBatch(object):
              and their edge index tensors.
             edge_weight_dict (Dictionary of keys=Tuples and values=Numpy arrays): Relation type tuples
              and their edge weight tensors.
-            feature_dicts (List of dictionaries where keys=Strings and values=Numpy arrays): List of node
+            feature_dicts (Sequence of dictionaries where keys=Strings and values=Numpy arrays): Sequence of node
              types and their feature tensors.
-            target_dicts (List of dictionaries where keys=Strings and values=Numpy arrays): List of node
+            target_dicts (Sequence of dictionaries where keys=Strings and values=Numpy arrays): Sequence of node
              types and their label (target) tensors.
             batch_dict (Dictionary of keys=Strings and values=Numpy arrays): Batch index tensor of each
              node type.
-            **kwargs (optional List of dictionaries where keys=Strings and values=Numpy arrays): List
+            **kwargs (optional Sequence of dictionaries where keys=Strings and values=Numpy arrays): Sequence
              of node types and their additional attributes.
         """
 


### PR DESCRIPTION
I propose replacing `List` type hints with `Sequence` for signal class constructor parameters. I noticed that the way these parameters are used is consistent with `Sequence`.

There are some use cases where passing a collection that is not a `List` is beneficial. For example, when using `DynamicGraphTemporalSignal` datasets, the changes in the graph structure may occur only once in hundreds or thousands of timesteps, and copying the same data so many times is extremely memory-inefficient. Here is a proof-of-concept class that a user may want to use in such a situation:

```
class DeduplicatedList(MutableSequence):
    """
    This is a somewhat confusing and poorly implemented collection that I
    do not recommend copying. Its purpose is to efficiently store a list
    that consists of long contiguous ranges of repeating elements.
    """

    def __init__(self):
        self.data = OrderedDict()
        self.index = 0

    def __getitem__(self, index: int):
        while index < 0:
            index += len(self)
        for rng, item in self.data.items():
            if index in rng:
                return item
        raise IndexError

    def __setitem__(self, index: int, value: _T) -> None:
        raise NotImplementedError

    def __delitem__(self, index: int) -> None:
        raise NotImplementedError

    def __iter__(self):
        for rng, item in self.data.items():
            for _ in rng:
                yield item

    def __len__(self) -> int:
        return self.index

    def insert(self, index: int, value: _T) -> None:
        """
        Pardon the confusion, but this method actually _appends_ `index`
        elements `value` to the collection. This one just has a more
        suitable signature than `append`.
        """
        self.data[range(self.index, self.index + index)] = value
        self.index += index
```

Of course, the proposed change does not change the functionality in any way; it only removes a potential source of confusion for the users and explicitly shows that they may use a `Sequence` of their choice. Therefore, no tests should be required.