### PR TITLE
Return type annotation of GCLSTM and GConvLSTM forward changed to Tuple

### DIFF
--- a/torch_geometric_temporal/nn/recurrent/gc_lstm.py
+++ b/torch_geometric_temporal/nn/recurrent/gc_lstm.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import torch
 from torch.nn import Parameter
 from torch_geometric.nn import ChebConv
@@ -174,7 +176,7 @@ class GCLSTM(torch.nn.Module):
         H: torch.FloatTensor = None,
         C: torch.FloatTensor = None,
         lambda_max: torch.Tensor = None,
-    ) -> torch.FloatTensor:
+    ) -> Tuple[torch.FloatTensor, torch.FloatTensor]:
         """
         Making a forward pass. If edge weights are not present the forward pass
         defaults to an unweighted graph. If the hidden state and cell state

--- a/torch_geometric_temporal/nn/recurrent/gconv_lstm.py
+++ b/torch_geometric_temporal/nn/recurrent/gconv_lstm.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import torch
 from torch.nn import Parameter
 from torch_geometric.nn import ChebConv
@@ -207,7 +209,7 @@ class GConvLSTM(torch.nn.Module):
         H: torch.FloatTensor = None,
         C: torch.FloatTensor = None,
         lambda_max: torch.Tensor = None,
-    ) -> torch.FloatTensor:
+    ) -> Tuple[torch.FloatTensor, torch.FloatTensor]:
         """
         Making a forward pass. If edge weights are not present the forward pass
         defaults to an unweighted graph. If the hidden state and cell state


### PR DESCRIPTION
`forward` of GConvLSTM and GCLSTM return two FloatTensors, `H` and `C`. This PR reflects that in the signature, by changing the return type from `torch.FloatTensor` to `Tuple[torch.FloatTensor, torch.FloatTensor]`.