### PR TITLE
Fix `test_tsagcn`

### DIFF
--- a/test/attention_test.py
+++ b/test/attention_test.py
@@ -557,9 +557,9 @@ def test_mtgnn():
     num_sub = int(num_nodes / num_split)
     for j in range(num_split):
         if j != num_split - 1:
-            id = perm[j * num_sub : (j + 1) * num_sub]
+            id = perm[j * num_sub: (j + 1) * num_sub]
         else:
-            id = perm[j * num_sub :]
+            id = perm[j * num_sub:]
         tx = trainx[:, :, id, :]
         output = model(tx, A_tilde, idx=id)
         output = output.transpose(1, 3)
@@ -652,9 +652,9 @@ def test_mtgnn():
     trainx = trainx.transpose(1, 3)
     for j in range(num_split):
         if j != num_split - 1:
-            id = perm[j * num_sub : (j + 1) * num_sub]
+            id = perm[j * num_sub: (j + 1) * num_sub]
         else:
-            id = perm[j * num_sub :]
+            id = perm[j * num_sub:]
         tx = trainx[:, :, id, :]
         output = model(tx, A_tilde, idx=id)
         output = output.transpose(1, 3)
@@ -690,6 +690,7 @@ def test_tsagcn():
     # (bs, seq, nodes, f_in) -> (bs, f_in, seq, nodes)
     # also be sure to pass in a contiguous tensor (the created in create_mock_batch() is not!)
     batch = batch.permute(0, 3, 1, 2).contiguous()
+    edge_index = edge_index.to(device)
 
     stride = 2
     aagcn_adaptive = AAGCN(
@@ -744,3 +745,5 @@ def test_dnntsp():
     z = model(node_features, edges, edge_weight)
 
     assert z.shape == (10, 100, 16)
+
+test_tsagcn()

--- a/test/attention_test.py
+++ b/test/attention_test.py
@@ -745,5 +745,3 @@ def test_dnntsp():
     z = model(node_features, edges, edge_weight)
 
     assert z.shape == (10, 100, 16)
-
-test_tsagcn()

--- a/torch_geometric_temporal/nn/attention/tsagcn.py
+++ b/torch_geometric_temporal/nn/attention/tsagcn.py
@@ -27,7 +27,7 @@ class GraphAAGCN:
         self.A = self.get_spatial_graph(self.num_nodes)
 
     def get_spatial_graph(self, num_nodes):
-        self_mat = torch.eye(num_nodes)
+        self_mat = torch.eye(num_nodes, device=self.edge_index.device)
         inward_mat = torch.squeeze(to_dense_adj(self.edge_index))
         inward_mat_norm = F.normalize(inward_mat, dim=0, p=1)
         outward_mat = inward_mat.transpose(0, 1)


### PR DESCRIPTION
Fix the issue in #186 
Changes
* send `edge_index` to `device`
* assign `self_mat` to `device` to match `edge_index`
* passed the `pytest`
```bash
$ pytest test/
============================================ test session starts =============================================
platform linux -- Python 3.7.16, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/***/pytorch_geometric_temporal
collected 93 items                                                                                           

test/attention_test.py ........                                                                        [  8%]
test/batch_test.py .............................                                                       [ 39%]
test/dataset_test.py ..........................................                                        [ 84%]
test/heterogeneous_test.py .                                                                           [ 86%]
test/recurrent_test.py .............                                                                   [100%]

======================================= 93 passed in 119.87s (0:01:59) =======================================
```

