### PR TITLE
Remove an extra argument in MPNNLSTM example

### DIFF
--- a/examples/recurrent/mpnnlstm_example.py
+++ b/examples/recurrent/mpnnlstm_example.py
@@ -20,7 +20,7 @@ train_dataset, test_dataset = temporal_signal_split(dataset, train_ratio=0.2)
 class RecurrentGCN(torch.nn.Module):
     def __init__(self, node_features):
         super(RecurrentGCN, self).__init__()
-        self.recurrent = MPNNLSTM(node_features, 32, 32, 20, 1, 0.5)
+        self.recurrent = MPNNLSTM(node_features, 32, 20, 1, 0.5)
         self.linear = torch.nn.Linear(2*32 + node_features, 1)
 
     def forward(self, x, edge_index, edge_weight):


### PR DESCRIPTION
fix MPNNLSTM example error related to commit 609148a 

```
❯ python ./examples/recurrent/mpnnlstm_example.py
Traceback (most recent call last):
  File "D:\repo\RyushiAok\pytorch_geometric_temporal\examples\recurrent\mpnnlstm_example.py", line 32, in <module>
    model = RecurrentGCN(node_features = 4)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\repo\RyushiAok\pytorch_geometric_temporal\examples\recurrent\mpnnlstm_example.py", line 23, in __init__
    self.recurrent = MPNNLSTM(node_features, 32, 32, 20, 1, 0.5)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: MPNNLSTM.__init__() takes 6 positional arguments but 7 were given
```