### PR TITLE
🐛 Fix SSL: CERTIFICATE_VERIFY_FAILED error

### DIFF
--- a/torch_geometric_temporal/dataset/chickenpox.py
+++ b/torch_geometric_temporal/dataset/chickenpox.py
@@ -1,5 +1,6 @@
 import json
-import urllib
+import ssl
+import urllib.request
 import numpy as np
 from ..signal import StaticGraphTemporalSignal
 
@@ -19,7 +20,11 @@ class ChickenpoxDatasetLoader(object):
 
     def _read_web_data(self):
         url = "https://raw.githubusercontent.com/benedekrozemberczki/pytorch_geometric_temporal/master/dataset/chickenpox.json"
-        self._dataset = json.loads(urllib.request.urlopen(url).read())
+
+        context = ssl._create_unverified_context()
+        self._dataset = json.loads(
+            urllib.request.urlopen(url, context=context).read()
+        )
 
     def _get_edges(self):
         self._edges = np.array(self._dataset["edges"]).T

--- a/torch_geometric_temporal/dataset/encovid.py
+++ b/torch_geometric_temporal/dataset/encovid.py
@@ -1,5 +1,6 @@
 import json
-import urllib
+import ssl
+import urllib.request
 import numpy as np
 from ..signal import DynamicGraphTemporalSignal
 
@@ -21,7 +22,8 @@ class EnglandCovidDatasetLoader(object):
 
     def _read_web_data(self):
         url = "https://raw.githubusercontent.com/benedekrozemberczki/pytorch_geometric_temporal/master/dataset/england_covid.json"
-        self._dataset = json.loads(urllib.request.urlopen(url).read())
+        context = ssl._create_unverified_context()
+        self._dataset = json.loads(urllib.request.urlopen(url, context=context).read())
 
     def _get_edges(self):
         self._edges = []

--- a/torch_geometric_temporal/dataset/metr_la.py
+++ b/torch_geometric_temporal/dataset/metr_la.py
@@ -1,5 +1,6 @@
 import os
-import urllib
+import ssl
+import urllib.request
 import zipfile
 import numpy as np
 import torch
@@ -25,7 +26,8 @@ class METRLADatasetLoader(object):
         self._read_web_data()
 
     def _download_url(self, url, save_path):  # pragma: no cover
-        with urllib.request.urlopen(url) as dl_file:
+        context = ssl._create_unverified_context()
+        with urllib.request.urlopen(url, context=context) as dl_file:
             with open(save_path, "wb") as out_file:
                 out_file.write(dl_file.read())
 

--- a/torch_geometric_temporal/dataset/montevideo_bus.py
+++ b/torch_geometric_temporal/dataset/montevideo_bus.py
@@ -1,6 +1,7 @@
 from typing import List
 import json
-import urllib
+import ssl
+import urllib.request
 import numpy as np
 from torch_geometric_temporal.signal import StaticGraphTemporalSignal
 
@@ -22,7 +23,8 @@ class MontevideoBusDatasetLoader(object):
 
     def _read_web_data(self):
         url = "https://raw.githubusercontent.com/benedekrozemberczki/pytorch_geometric_temporal/master/dataset/montevideo_bus.json"
-        self._dataset = json.loads(urllib.request.urlopen(url).read())
+        context = ssl._create_unverified_context()
+        self._dataset = json.loads(urllib.request.urlopen(url, context=context).read())
 
     def _get_node_ids(self):
         return [node.get('bus_stop') for node in self._dataset["nodes"]]

--- a/torch_geometric_temporal/dataset/mtm.py
+++ b/torch_geometric_temporal/dataset/mtm.py
@@ -1,5 +1,6 @@
 import json
-import urllib
+import ssl
+import urllib.request
 import numpy as np
 from torch_geometric_temporal.signal import StaticGraphTemporalSignal
 
@@ -22,7 +23,8 @@ class MTMDatasetLoader:
 
     def _read_web_data(self):
         url = "https://raw.githubusercontent.com/benedekrozemberczki/pytorch_geometric_temporal/master/dataset/mtm_1.json"
-        self._dataset = json.loads(urllib.request.urlopen(url).read())
+        context = ssl._create_unverified_context()
+        self._dataset = json.loads(urllib.request.urlopen(url, context=context).read())
 
     def _get_edges(self):
         self._edges = np.array(self._dataset["edges"]).T

--- a/torch_geometric_temporal/dataset/pedalme.py
+++ b/torch_geometric_temporal/dataset/pedalme.py
@@ -1,5 +1,6 @@
 import json
-import urllib
+import ssl
+import urllib.request
 import numpy as np
 from ..signal import StaticGraphTemporalSignal
 
@@ -18,7 +19,8 @@ class PedalMeDatasetLoader(object):
 
     def _read_web_data(self):
         url = "https://raw.githubusercontent.com/benedekrozemberczki/pytorch_geometric_temporal/master/dataset/pedalme_london.json"
-        self._dataset = json.loads(urllib.request.urlopen(url).read())
+        context = ssl._create_unverified_context()
+        self._dataset = json.loads(urllib.request.urlopen(url, context=context).read())
 
     def _get_edges(self):
         self._edges = np.array(self._dataset["edges"]).T

--- a/torch_geometric_temporal/dataset/pems_bay.py
+++ b/torch_geometric_temporal/dataset/pems_bay.py
@@ -1,5 +1,6 @@
 import os
-import urllib
+import ssl
+import urllib.request
 import zipfile
 import numpy as np
 import torch
@@ -25,7 +26,8 @@ class PemsBayDatasetLoader(object):
         self._read_web_data()
 
     def _download_url(self, url, save_path):  # pragma: no cover
-        with urllib.request.urlopen(url) as dl_file:
+        context = ssl._create_unverified_context()
+        with urllib.request.urlopen(url, context=context) as dl_file:
             with open(save_path, "wb") as out_file:
                 out_file.write(dl_file.read())
 

--- a/torch_geometric_temporal/dataset/twitter_tennis.py
+++ b/torch_geometric_temporal/dataset/twitter_tennis.py
@@ -1,5 +1,6 @@
 import json
-import urllib
+import ssl
+import urllib.request
 import numpy as np
 from ..signal import DynamicGraphTemporalSignal
 
@@ -78,7 +79,8 @@ class TwitterTennisDatasetLoader(object):
             "https://raw.githubusercontent.com/ferencberes/pytorch_geometric_temporal/developer/dataset/"
             + fname
         )
-        self._dataset = json.loads(urllib.request.urlopen(url).read())
+        context = ssl._create_unverified_context()
+        self._dataset = json.loads(urllib.request.urlopen(url, context=context).read())
         # with open("/home/fberes/git/pytorch_geometric_temporal/dataset/"+fname) as f:
         #    self._dataset = json.load(f)
 

--- a/torch_geometric_temporal/dataset/wikimath.py
+++ b/torch_geometric_temporal/dataset/wikimath.py
@@ -1,5 +1,6 @@
 import json
-import urllib
+import ssl
+import urllib.request
 import numpy as np
 from ..signal import StaticGraphTemporalSignal
 
@@ -19,7 +20,8 @@ class WikiMathsDatasetLoader(object):
 
     def _read_web_data(self):
         url = "https://raw.githubusercontent.com/benedekrozemberczki/pytorch_geometric_temporal/master/dataset/wikivital_mathematics.json"
-        self._dataset = json.loads(urllib.request.urlopen(url).read())
+        context = ssl._create_unverified_context()
+        self._dataset = json.loads(urllib.request.urlopen(url, context=context).read())
 
     def _get_edges(self):
         self._edges = np.array(self._dataset["edges"]).T

--- a/torch_geometric_temporal/dataset/windmilllarge.py
+++ b/torch_geometric_temporal/dataset/windmilllarge.py
@@ -1,5 +1,6 @@
 import json
-import urllib
+import ssl
+import urllib.request
 import numpy as np
 from ..signal import StaticGraphTemporalSignal
 
@@ -16,7 +17,10 @@ class WindmillOutputLargeDatasetLoader(object):
 
     def _read_web_data(self):
         url = "https://graphmining.ai/temporal_datasets/windmill_output.json"
-        self._dataset = json.loads(urllib.request.urlopen(url).read().decode())
+        context = ssl._create_unverified_context()
+        self._dataset = json.loads(
+            urllib.request.urlopen(url, context=context).read().decode()
+        )
 
     def _get_edges(self):
         self._edges = np.array(self._dataset["edges"]).T

--- a/torch_geometric_temporal/dataset/windmillmedium.py
+++ b/torch_geometric_temporal/dataset/windmillmedium.py
@@ -1,5 +1,6 @@
 import json
-import urllib
+import ssl
+import urllib.request
 import numpy as np
 from ..signal import StaticGraphTemporalSignal
 
@@ -16,7 +17,10 @@ class WindmillOutputMediumDatasetLoader(object):
 
     def _read_web_data(self):
         url = "https://graphmining.ai/temporal_datasets/windmill_output_medium.json"
-        self._dataset = json.loads(urllib.request.urlopen(url).read().decode())
+        context = ssl._create_unverified_context()
+        self._dataset = json.loads(
+            urllib.request.urlopen(url, context=context).read().decode()
+        )
 
     def _get_edges(self):
         self._edges = np.array(self._dataset["edges"]).T

--- a/torch_geometric_temporal/dataset/windmillsmall.py
+++ b/torch_geometric_temporal/dataset/windmillsmall.py
@@ -1,5 +1,6 @@
 import json
-import urllib
+import ssl
+import urllib.request
 import numpy as np
 from ..signal import StaticGraphTemporalSignal
 
@@ -16,7 +17,10 @@ class WindmillOutputSmallDatasetLoader(object):
 
     def _read_web_data(self):
         url = "https://graphmining.ai/temporal_datasets/windmill_output_small.json"
-        self._dataset = json.loads(urllib.request.urlopen(url).read().decode())
+        context = ssl._create_unverified_context()
+        self._dataset = json.loads(
+            urllib.request.urlopen(url, context=context).read().decode()
+        )
 
     def _get_edges(self):
         self._edges = np.array(self._dataset["edges"]).T


### PR DESCRIPTION
#### tl;dr

Made the fix for `SSL: CERTIFICATE_VERIFY_FAILED` error that is encountered while downloading the dataset for each dataloader. This is fixed by passing an unverified SSL context to the urllib.request.urlopen() method.

---

This pull request is in regards to the following issues #255, #243 and #236. I had also faced a similar issue when trying to download the datasets for the dataloader.

### Reproducing the error

Ran the following Python script to load the `METRLADatasetLoader` 

```python3
import torch_geometric_temporal
from torch_geometric_temporal.dataset import METRLADatasetLoader

metrla = METRLADatasetLoader()
```
 
And encountered the following error

```bash
Traceback (most recent call last):
  File "/home/nithin/anaconda3/envs/seastar-new/lib/python3.10/urllib/request.py", line 1348, in do_open
    h.request(req.get_method(), req.selector, req.data, headers,
  File "/home/nithin/anaconda3/envs/seastar-new/lib/python3.10/http/client.py", line 1282, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/home/nithin/anaconda3/envs/seastar-new/lib/python3.10/http/client.py", line 1328, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/home/nithin/anaconda3/envs/seastar-new/lib/python3.10/http/client.py", line 1277, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/home/nithin/anaconda3/envs/seastar-new/lib/python3.10/http/client.py", line 1037, in _send_output
    self.send(msg)
  File "/home/nithin/anaconda3/envs/seastar-new/lib/python3.10/http/client.py", line 975, in send
    self.connect()
  File "/home/nithin/anaconda3/envs/seastar-new/lib/python3.10/http/client.py", line 1454, in connect
    self.sock = self._context.wrap_socket(self.sock,
  File "/home/nithin/anaconda3/envs/seastar-new/lib/python3.10/ssl.py", line 513, in wrap_socket
    return self.sslsocket_class._create(
  File "/home/nithin/anaconda3/envs/seastar-new/lib/python3.10/ssl.py", line 1071, in _create
    self.do_handshake()
  File "/home/nithin/anaconda3/envs/seastar-new/lib/python3.10/ssl.py", line 1342, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:997)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mnt/c/Nithin stuff/Open Source Contributions/pytorch_geometric_temporal/torch_geometric_temporal/dataset/metr_la.py", line 25, in __init__
    self._read_web_data()
  File "/mnt/c/Nithin stuff/Open Source Contributions/pytorch_geometric_temporal/torch_geometric_temporal/dataset/metr_la.py", line 41, in _read_web_data
    self._download_url(url, os.path.join(self.raw_data_dir, "METR-LA.zip"))
  File "/mnt/c/Nithin stuff/Open Source Contributions/pytorch_geometric_temporal/torch_geometric_temporal/dataset/metr_la.py", line 28, in _download_url
    with urllib.request.urlopen(url) as dl_file:
  File "/home/nithin/anaconda3/envs/seastar-new/lib/python3.10/urllib/request.py", line 216, in urlopen
    return opener.open(url, data, timeout)
  File "/home/nithin/anaconda3/envs/seastar-new/lib/python3.10/urllib/request.py", line 519, in open
    response = self._open(req, data)
  File "/home/nithin/anaconda3/envs/seastar-new/lib/python3.10/urllib/request.py", line 536, in _open
    result = self._call_chain(self.handle_open, protocol, protocol +
  File "/home/nithin/anaconda3/envs/seastar-new/lib/python3.10/urllib/request.py", line 496, in _call_chain
    result = func(*args)
  File "/home/nithin/anaconda3/envs/seastar-new/lib/python3.10/urllib/request.py", line 1391, in https_open
    return self.do_open(http.client.HTTPSConnection, req,
  File "/home/nithin/anaconda3/envs/seastar-new/lib/python3.10/urllib/request.py", line 1351, in do_open
    raise URLError(err)
urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:997)>
```

And noticed that the tests for the dataset loaders were failing due to the similar error

![pygt-pr-test](https://github.com/benedekrozemberczki/pytorch_geometric_temporal/assets/64126131/0ec116a4-9484-491e-9c29-f6540435207a)

### The fix for the error

The fix was inspired by what [PyTorch Geometric](https://github.com/pyg-team/pytorch_geometric) had done to bypass the `SSL: CERTIFICATE_VERIFY_FAILED` error. All they did was pass an unverified SSL context to the `urllib.request.urlopen()` method call.

```python3
context = ssl._create_unverified_context()
self._dataset = json.loads(
    urllib.request.urlopen(url, context=context).read()
)
```

The PyTorch Geometric code were they did that to download the datasets can be found [here](https://github.com/pyg-team/pytorch_geometric/blob/0e526ab546b135dd8d5fbd55174d74da1e4028be/torch_geometric/data/download.py#L46).

A similar solution was also mentioned in a [comment](https://github.com/benedekrozemberczki/pytorch_geometric_temporal/issues/236#issuecomment-1620911112) inside issue #236.

And upon running the tests, we are not encountering the previous errors anymore

![pygt-pr-test-fix](https://github.com/benedekrozemberczki/pytorch_geometric_temporal/assets/64126131/ad8eecf1-b920-4a02-b5de-442fe36e0913)
