### PR TITLE
Remove pandas requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ install_requires = [
     "decorator==4.4.2",
     "torch",
     "cython",
-    "pandas<=1.3.5",
     "torch_sparse",
     "torch_scatter",
     "torch_geometric",
@@ -49,7 +48,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         "test": tests_require,
-    },    
+    },
     python_requires=">=3.6",
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
As pointed out in [this issue](https://github.com/benedekrozemberczki/pytorch_geometric_temporal/issues/260), pandas don't seem to have been directly used in the repo. In this PR, I'm removing the requirement because having `pandas <=1.3.5` causes dependency issues with other packages.