### PR TITLE
fix weight in-place update

### DIFF
--- a/examples/recurrent/evolvegcnh_example.py
+++ b/examples/recurrent/evolvegcnh_example.py
@@ -23,11 +23,11 @@ class RecurrentGCN(torch.nn.Module):
         self.recurrent = EvolveGCNH(node_count, node_features)
         self.linear = torch.nn.Linear(node_features, 1)
 
-    def forward(self, x, edge_index, edge_weight):
-        h = self.recurrent(x, edge_index, edge_weight)
+    def forward(self, x, edge_index, edge_weight, w):
+        h, w = self.recurrent(x, edge_index, edge_weight, w)
         h = F.relu(h)
         h = self.linear(h)
-        return h
+        return h, w
         
 model = RecurrentGCN(node_features = 4, node_count = 20)
 
@@ -37,8 +37,9 @@ model.train()
 
 for epoch in tqdm(range(200)):
     cost = 0
+    w = None
     for time, snapshot in enumerate(train_dataset):
-        y_hat = model(snapshot.x, snapshot.edge_index, snapshot.edge_attr)
+        y_hat, w = model(snapshot.x, snapshot.edge_index, snapshot.edge_attr, w)
         cost = cost + torch.mean((y_hat-snapshot.y)**2)
     cost = cost / (time+1)
     cost.backward()
@@ -48,7 +49,7 @@ for epoch in tqdm(range(200)):
 model.eval()
 cost = 0
 for time, snapshot in enumerate(test_dataset):
-    y_hat = model(snapshot.x, snapshot.edge_index, snapshot.edge_attr)
+    y_hat, w = model(snapshot.x, snapshot.edge_index, snapshot.edge_attr, w)
     cost = cost + torch.mean((y_hat-snapshot.y)**2)
 cost = cost / (time+1)
 cost = cost.item()

--- a/torch_geometric_temporal/nn/recurrent/evolvegcnh.py
+++ b/torch_geometric_temporal/nn/recurrent/evolvegcnh.py
@@ -45,16 +45,12 @@ class EvolveGCNH(torch.nn.Module):
         self.cached = cached
         self.normalize = normalize
         self.add_self_loops = add_self_loops
-        self.weight = None
         self.initial_weight = torch.nn.Parameter(torch.Tensor(1, in_channels, in_channels))
         self._create_layers()
         self.reset_parameters()
     
     def reset_parameters(self):
         glorot(self.initial_weight)
-
-    def reinitialize_weight(self):
-        self.weight = None
 
     def _create_layers(self):
 
@@ -80,6 +76,7 @@ class EvolveGCNH(torch.nn.Module):
         X: torch.FloatTensor,
         edge_index: torch.LongTensor,
         edge_weight: torch.FloatTensor = None,
+        W: torch.FloatTensor = None,
     ) -> torch.FloatTensor:
         """
         Making a forward pass.
@@ -88,15 +85,16 @@ class EvolveGCNH(torch.nn.Module):
             * **X** *(PyTorch Float Tensor)* - Node embedding.
             * **edge_index** *(PyTorch Long Tensor)* - Graph edge indices.
             * **edge_weight** *(PyTorch Float Tensor, optional)* - Edge weight vector.
-
+            * **W** *(PyTorch Float Tensor, optional)* - Weight matrix.
         Return types:
             * **X** *(PyTorch Float Tensor)* - Output matrix for all nodes.
+            * **W** *(PyTorch Float Tensor)* - Weight matrix.
         """
         X_tilde = self.pooling_layer(X, edge_index)
         X_tilde = X_tilde[0][None, :, :]
-        if self.weight is None:
-            _, self.weight = self.recurrent_layer(X_tilde, self.initial_weight)
+        if W is None:
+            _, W = self.recurrent_layer(X_tilde, self.initial_weight)
         else:
-            _, self.weight = self.recurrent_layer(X_tilde, self.weight)
-        X = self.conv_layer(self.weight.squeeze(dim=0), X, edge_index, edge_weight)
-        return X
+            _, W = self.recurrent_layer(X_tilde, W)
+        X = self.conv_layer(W.squeeze(dim=0), X, edge_index, edge_weight)
+        return X, W


### PR DESCRIPTION
An in-place update on `self.weight` in EvolveGCNH raises RuntimeError as shown in the screenshot below, with Python 3.10.15 + torch-2.4.0+cu121 + pyg 2.6.1, and the `pytorch_geometric_temporal` is installed from source.

```python
class EvolveGCNH(torch.nn.Module):
    def forward(self, X, edge_index, edge_weight):
         ...
         if self.weight is None:
            _, self.weight = self.recurrent_layer(X_tilde, self.initial_weight)
        else:
            _, self.weight = self.recurrent_layer(X_tilde, self.weight)
        ...
```

![{9AF115E4-201B-4A69-B69F-40A216253CE6}](https://github.com/user-attachments/assets/bc4eab20-a696-421b-9226-c436d2a6e138)

Inspired by the `GCLSTM` example, I dropped `self.weight` and made it an argument.