### PR TITLE
Issue 291: Fix view error in AAGCN by replacing view() with reshape()

### DIFF
--- a/torch_geometric_temporal/nn/attention/tsagcn.py
+++ b/torch_geometric_temporal/nn/attention/tsagcn.py
@@ -237,7 +237,7 @@ class UnitGCN(nn.Module):
                 .contiguous()
                 .view(N, V, self.inter_c * T)
             )
-            A2 = self.conv_b[i](x).view(N, self.inter_c * T, V)
+            A2 = self.conv_b[i](x).reshape(N, self.inter_c * T, V)
             A1 = self.tan(torch.matmul(A1, A2) / A1.size(-1))  # N V V
             A1 = A[i] + A1 * self.alpha
             A2 = x.view(N, C * T, V)


### PR DESCRIPTION
## Description
This PR fixes an issue in the AAGCN layer where `view()` was causing an error due to incompatible tensor shapes. Replaced `view()` calls with `reshape()` to handle non-contiguous tensors.

## Related Issue
Fixes issue 291:
https://github.com/benedekrozemberczki/pytorch_geometric_temporal/issues/291