### PR TITLE
Index-batching functionality

### DIFF
--- a/docs/source/modules/dataset.rst
+++ b/docs/source/modules/dataset.rst
@@ -39,6 +39,14 @@ Datasets
     :members:
     :undoc-members:
 
+.. automodule:: torch_geometric_temporal.dataset.pemsAllLA
+    :members:
+    :undoc-members:
+
+.. automodule:: torch_geometric_temporal.dataset.pems
+    :members:
+    :undoc-members:
+
 .. automodule:: torch_geometric_temporal.dataset.encovid
     :members:
     :undoc-members:

--- a/docs/source/modules/signal.rst
+++ b/docs/source/modules/signal.rst
@@ -64,9 +64,19 @@ Heterogeneous Temporal Signal Batch Iterators
     :members:
     :undoc-members:
 
-Temporal Signal Train-Test Split
+Temporal Signal Index-batching Iterators
 --------------------------------
 
+
+.. automodule:: torch_geometric_temporal.signal.index_dataset
+    :members:
+    :undoc-members:
+
+Temporal Signal Train-Test Split
+--------------------------------
 .. automodule:: torch_geometric_temporal.signal.temporal_signal_split
     :members:
     :undoc-members:
+
+
+

--- a/docs/source/modules/signal.rst
+++ b/docs/source/modules/signal.rst
@@ -64,7 +64,7 @@ Heterogeneous Temporal Signal Batch Iterators
     :members:
     :undoc-members:
 
-Temporal Signal Index-batching Iterators
+Temporal Signal Index-Batching Iterators
 --------------------------------
 
 

--- a/docs/source/notes/installation.rst
+++ b/docs/source/notes/installation.rst
@@ -30,3 +30,22 @@ To check your current package version just simply run:
 
         $ pip freeze | grep torch-geometric-temporal
 
+**Index-Batching**
+
+The package was recently updated to include index-batching, a new method of batching that improves 
+memory efficiency without any impact on accuracy. To install the needed packages for index-batching,
+run the following command:
+
+    .. code-block:: none
+
+        $ pip install torch-geometric-temporal[index]
+
+**Distributed Data Parallel**
+
+Alongside index-batching, PGT was recently updated with features to support distributed data parallel training.
+To install the needed packages, run the following: 
+
+    .. code-block:: none
+
+        $ pip install torch-geometric-temporal[ddp]
+

--- a/examples/indexBatching/README.md
+++ b/examples/indexBatching/README.md
@@ -1,0 +1,57 @@
+## PyTorch Geometric Temporal - Index
+
+Index-batching is a technique that reduces the memory cost of training ST-GNNs with spatiotemporal data with no impact on accurary, enabling greater scalability and training on the full PeMS dataset without graph partioning for the first time. Leveraging the reduced memory footprint, this techique also enables GPU-index-batching - a technique that performs preprocessing entirely in GPU memory and utilizes a single CPU-to-GPU mem-copy in place of batch-level CPU-to-GPU transfers throughout training. We implemented GPU-index-batching and index-batching for the following existing datasets and added two new datasts (highlighted in bold) to PyTorch Geometric Temporal (PGT): 
+
+* PeMs-Bay
+* WindmillLarge
+* HungaryChickenpox
+* **PeMSAllLA**
+* **PeMS**
+
+Utilizing index-batching requires minimal modifications to the existing PGT workflow. For example, the following is a sample training loop with static graph dataset with temporal signal:
+
+```
+train_dataloader, _, _, edges, edge_weights, means, stds = loader.get_index_dataset(batch_size=batch_size)
+
+for batch in train_dataloader:
+            X_batch, y_batch = batch
+
+            # Forward pass
+            outputs = model(X_batch, edges, edge_weights) 
+
+            # Calculate loss 
+            loss = masked_mae_loss((outputs * std) + mean, (y_batch * std) + mean)
+
+            # Backward pass
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+
+```
+
+The single-GPU examples in this repo can be executed as follows: `python3 <datasetName>.py` and have the following parameters:
+
+| Argument | Short Form | Type | Default | Description |
+|----------|-----------|------|---------|-------------|
+| `--epochs` | `-e` | `int` | `30` | The desired number of training epochs. |
+| `--batch-size` | `-bs` | `int` | `64` | The desired batch size for training. |
+| `--gpu` | `-g` | `str` | `"False"` | Indicates whether data should be preprocessed and migrated directly to the GPU. Use `"True"` to enable GPU processing. |
+| `--debug` | `-d` | `str` | `"False"` | Enables debug mode, printing values for debugging. Use `"True"` to enable debugging. |
+
+
+
+We also provide a multi-node, multi-GPU Dask-DDP training implementation for PeMS-Bay, PemsAllLA, and the full PeMS dataset. It has the following parameters:
+
+| Argument | Short Form | Type | Default | Description |
+|----------|-----------|------|---------|-------------|
+| `--epochs` | `-e` | `int` | `100` | The desired number of training epochs. |
+| `--batch-size` | `-bs` | `int` | `64` | The desired batch size for training. |
+| `--gpu` | `-g` | `str` | `"False"` | Indicates whether data should be preprocessed and migrated directly to the GPU. Use `"True"` to enable GPU processing. |
+| `--debug` | `-d` | `str` | `"False"` | Enables debug mode, printing values for debugging. Use `"True"` to enable debugging. |
+| `--dask-cluster-file` | N/A | `str` | `""` | Path to the Dask scheduler file for the Dask CLI interface. |
+| `--npar` | `-np` | `int` | `1` | The number of GPUs or workers per node. |
+| `--dataset` | N/A | `str` | `"pems-bay"` | Specifies which dataset is in use (e.g., PeMS-Bay, PeMS-All-LA, PeMS). |
+
+To execute in a single node, omit the `--dask-cluster-file` argument. To run multi-node, setup a Dask scheduler and dask workers user the [Dask command line interface](https://docs.dask.org/en/latest/deploying-cli.html) and pass the scheduler file via `--dask-cluster-file`. An example multi-GPU, multi-node script for Argonne's [Polaris supercomputer](https://www.alcf.anl.gov/polaris)  is shown in `submit.sh`. 
+

--- a/examples/indexBatching/chicken_pox_main.py
+++ b/examples/indexBatching/chicken_pox_main.py
@@ -134,9 +134,9 @@ def main():
     t1 = time.time()
     loader = ChickenpoxDatasetLoader()
     if allGPU == True:
-        train_dataloader, val_dataloader, test_dataloader, edges, edge_weights = loader.get_index_dataset(allGPU=0)
+        train_dataloader, val_dataloader, test_dataloader, edges, edge_weights = loader.get_index_dataset(allGPU=0,batch_size=batch_size)
     else:
-        train_dataloader, val_dataloader, test_dataloader, edges, edge_weights = loader.get_index_dataset()
+        train_dataloader, val_dataloader, test_dataloader, edges, edge_weights = loader.get_index_dataset(batch_size=batch_size)
     
     t_min, v_min = train(train_dataloader, val_dataloader, edges, edge_weights, epochs, 4,20,1, allGPU=allGPU, debug=debug)
     t2 = time.time()

--- a/examples/indexBatching/chicken_pox_main.py
+++ b/examples/indexBatching/chicken_pox_main.py
@@ -1,8 +1,6 @@
 
 from torch_geometric_temporal.nn.recurrent import BatchedDCRNN as DCRNN
 from torch_geometric_temporal.dataset import ChickenpoxDatasetLoader
-
-import torch.nn as nn
 import torch.optim as optim
 
 import argparse

--- a/examples/indexBatching/chicken_pox_main.py
+++ b/examples/indexBatching/chicken_pox_main.py
@@ -1,15 +1,16 @@
-import time 
-import csv
 
 from torch_geometric_temporal.nn.recurrent import BatchedDCRNN as DCRNN
+from torch_geometric_temporal.dataset import ChickenpoxDatasetLoader
+
 import torch.nn as nn
 import torch.optim as optim
+
 import argparse
-
-from utils import *
+import csv
 import os
+import time 
+from utils import *
 
-from torch_geometric_temporal.dataset import ChickenpoxDatasetLoader
 
 def parse_arguments():
     """Parse command-line arguments."""

--- a/examples/indexBatching/chicken_pox_main.py
+++ b/examples/indexBatching/chicken_pox_main.py
@@ -1,0 +1,147 @@
+import time 
+import csv
+
+from torch_geometric_temporal.nn.recurrent import BatchedDCRNN as DCRNN
+import torch.nn as nn
+import torch.optim as optim
+import argparse
+
+from utils import *
+import os
+
+from torch_geometric_temporal.dataset import ChickenpoxDatasetLoader
+
+def parse_arguments():
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description="Demo of index batching with chickenpox dataset")
+
+    parser.add_argument(
+        "-e", "--epochs", type=int, default=100, help="The desired number of training epochs"
+    )
+    parser.add_argument(
+        "-bs", "--batch-size", type=int, default=64, help="The desired batch size"
+    )
+    parser.add_argument(
+        "-m", "--mode", type=str, default="base", help="Which version to run"
+    )
+    parser.add_argument(
+        "-g", "--gpu", type=str, default="False", help="Should data be preprocessed and migrated directly to the GPU"
+    )
+    parser.add_argument(
+        "-d", "--debug", type=str, default="False", help="Print values for debugging"
+    )
+    
+    return parser.parse_args()
+
+def train(train_dataloader, val_dataloader, edge_index,edge_weight, epochs, seq_length, num_nodes, num_features, 
+            allGPU=False, debug=False):
+    
+    
+    # Move to GPU
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    edge_index = edge_index.to(device)
+    edge_weight = edge_weight.to(device)
+    
+    
+    # Initialize model
+    model = DCRNN(num_features, num_features, K=3).to(device)
+
+    # Define optimizer and loss function
+    optimizer = optim.Adam(model.parameters(), lr=0.001)
+
+    # Training loop
+    stats = []
+    min_t = 9999
+    min_v = 9999
+    for epoch in range(epochs):
+        # Training phase
+        model.train()
+        train_loss = 0.0
+        i = 1
+        total = len(train_dataloader)
+        t1 = time.time()
+        for batch in train_dataloader:
+            X_batch, y_batch = batch
+            
+            if allGPU == False:
+
+                X_batch = X_batch.to(device).float()
+                y_batch = y_batch.to(device).float()
+            
+            # Forward pass
+            outputs = model(X_batch, edge_index, edge_weight)  # Shape: (batch_size, seq_length, num_nodes, out_channels)
+
+            # Calculate loss (use only the first output channel, assuming it's the target)
+            loss = masked_mae_loss(outputs,y_batch )
+           
+            # Backward pass
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+            train_loss += loss.item()
+            if debug:
+                print(f"Train Batch: {i}/{total}", end="\r")
+                i+=1
+        
+
+        train_loss /= len(train_dataloader)
+
+        # Validation phase
+        model.eval()
+        val_loss = 0.0
+        i = 0
+        if debug:
+            print("                      ", end="\r")
+        total = len(val_dataloader)
+        with torch.no_grad():
+            for batch in val_dataloader:
+                X_batch, y_batch = batch
+
+                if allGPU == False:
+                    X_batch = X_batch.to(device).float()
+                    y_batch = y_batch.to(device).float()
+
+                # Forward pass
+                outputs = model(X_batch, edge_index, edge_weight)
+
+                # Calculate loss
+                loss = masked_mae_loss(outputs,y_batch)
+                val_loss += loss.item()
+                
+                if debug:
+                    print(f"Val Batch: {i}/{total}", end="\r")
+                    i += 1
+        
+        val_loss /= len(val_dataloader)
+        t2 = time.time()
+        # Print epoch metrics
+        print(f"Epoch {epoch + 1}/{epochs}, Runtime: {t2 - t1}, Train Loss: {train_loss:.4f}, Val Loss: {val_loss:.4f}", flush=True)
+        stats.append([epoch+1, t2 - t1, train_loss, val_loss])
+
+        min_t = min(min_t, train_loss)
+        min_v = min(min_v, val_loss)
+    
+    return min_t, min_v
+
+def main():
+
+    args = parse_arguments()
+    allGPU = args.gpu.lower() in ["true", "y", "t"]
+    debug = args.debug.lower() in ["true", "y", "t"]
+    batch_size = args.batch_size
+    epochs = args.epochs
+
+    t1 = time.time()
+    loader = ChickenpoxDatasetLoader()
+    if allGPU == True:
+        train_dataloader, val_dataloader, test_dataloader, edges, edge_weights = loader.get_index_dataset(allGPU=0)
+    else:
+        train_dataloader, val_dataloader, test_dataloader, edges, edge_weights = loader.get_index_dataset()
+    
+    t_min, v_min = train(train_dataloader, val_dataloader, edges, edge_weights, epochs, 4,20,1, allGPU=allGPU, debug=debug)
+    t2 = time.time()
+    print(f"Runtime: {round(t2 - t1,2)}; Best Train MSE: {t_min}; Best Validation MSE: {v_min}")
+    
+if __name__ == "__main__":
+    main()

--- a/examples/indexBatching/chicken_pox_main.py
+++ b/examples/indexBatching/chicken_pox_main.py
@@ -132,7 +132,7 @@ def main():
     epochs = args.epochs
 
     t1 = time.time()
-    loader = ChickenpoxDatasetLoader()
+    loader = ChickenpoxDatasetLoader(index=True)
     if allGPU == True:
         train_dataloader, val_dataloader, test_dataloader, edges, edge_weights = loader.get_index_dataset(allGPU=0,batch_size=batch_size)
     else:

--- a/examples/indexBatching/pems_allLA_main.py
+++ b/examples/indexBatching/pems_allLA_main.py
@@ -139,11 +139,6 @@ def main():
     else:
         train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, means, stds = loader.get_index_dataset(batch_size=batch_size)
     
-
-    sensor_ids, sensor_id_to_ind, adj_mx = load_graph_data("data/pems_cali_adj_mat.pkl")
-    edge_index, edge_weight = adjacency_to_edge_index(adj_mx)
-    
-
         
     t_min, v_min = train(train_dataloader, val_dataloader, means, stds, edges, edge_weights, epochs, 12,11160,2, allGPU=allGPU, debug=debug)
     t2 = time.time()

--- a/examples/indexBatching/pems_allLA_main.py
+++ b/examples/indexBatching/pems_allLA_main.py
@@ -1,0 +1,153 @@
+from torch_geometric_temporal.nn.recurrent import BatchedDCRNN as DCRNN
+from torch_geometric_temporal.dataset import PemsAllLADatasetLoader
+import torch.optim as optim
+
+import argparse
+import csv
+import os
+import time 
+from utils import *
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="Demo of index batching with PemsAllLA dataset")
+
+    parser.add_argument(
+        "-e", "--epochs", type=int, default=30, help="The desired number of training epochs"
+    )
+    parser.add_argument(
+        "-bs", "--batch-size", type=int, default=64, help="The desired batch size"
+    )
+    parser.add_argument(
+        "-g", "--gpu", type=str, default="False", help="Should data be preprocessed and migrated directly to the GPU"
+    )
+    parser.add_argument(
+        "-d", "--debug", type=str, default="False", help="Print values for debugging"
+    )
+    return parser.parse_args()
+
+
+
+
+def train(train_dataloader, val_dataloader, mean, std, edges, edge_weights, epochs, seq_length, num_nodes, num_features, allGPU=False, debug=False):
+    
+    # Move to GPU
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    edge_index = edges.to(device)
+    edge_weight = edge_weights.to(device)
+    
+    if allGPU == False:
+        mean = mean.to(device)
+        std = std.to(device)
+
+    # Initialize model
+    model = DCRNN(num_features, num_features, K=3).to(device)
+
+    # Define optimizer and loss function
+    optimizer = optim.Adam(model.parameters(), lr=0.001)
+
+    # Training loop
+    stats = []
+    min_t = 9999
+    min_v = 9999
+    for epoch in range(epochs):
+        # Training phase
+        model.train()
+        train_loss = 0.0
+        i = 1
+        total = len(train_dataloader)
+        t1 = time.time()
+        for batch in train_dataloader:
+            X_batch, y_batch = batch
+
+            if allGPU == False:
+                # print("casting")
+                X_batch = X_batch.to(device).float()
+                y_batch = y_batch.to(device).float()
+
+            # Forward pass
+            outputs = model(X_batch, edge_index, edge_weight)  # Shape: (batch_size, seq_length, num_nodes, out_channels)
+
+            # Calculate loss (use only the first output channel, assuming it's the target)
+            loss = masked_mae_loss((outputs * std) + mean, (y_batch * std) + mean)
+
+            # Backward pass
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+            train_loss += loss.item()
+            if debug:
+                print(f"Train Batch: {i}/{total}", end="\r")
+                i+=1
+            # break
+        
+
+        train_loss /= len(train_dataloader)
+
+        # Validation phase
+        model.eval()
+        val_loss = 0.0
+        i = 0
+        if debug:
+            print("                      ", end="\r")
+        total = len(val_dataloader)
+        with torch.no_grad():
+            for batch in val_dataloader:
+                X_batch, y_batch = batch
+
+                if allGPU == False:
+                    X_batch = X_batch.to(device).float()
+                    y_batch = y_batch.to(device).float()
+
+                # Forward pass
+                outputs = model(X_batch, edge_index, edge_weight)
+
+                # Calculate loss
+                loss = masked_mae_loss((outputs * std) + mean, (y_batch * std) + mean)
+                val_loss += loss.item()
+                if debug:
+                    print(f"Val Batch: {i}/{total}", end="\r")
+                    i += 1
+                
+
+        val_loss /= len(val_dataloader)
+        t2 = time.time()
+        # Print epoch metrics
+        print(f"Epoch {epoch + 1}/{epochs}, Runtime: {t2 - t1}, Train Loss: {train_loss:.4f}, Val Loss: {val_loss:.4f}", flush=True)
+        stats.append([epoch+1, t2 - t1, train_loss, val_loss])
+
+        min_t = min(min_t, train_loss)
+        min_v = min(min_v, val_loss)
+    
+    return min_t, min_v
+
+def main():
+  
+
+
+    args = parse_arguments()
+    allGPU = args.gpu.lower() in ["true", "y", "t", "yes"]
+    debug = args.debug.lower() in ["true", "y", "t", "yes"]
+    batch_size = args.batch_size
+    epochs = args.epochs
+
+    t1 = time.time()
+    loader = PemsAllLADatasetLoader(index=True)
+    if allGPU:
+        train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, means, stds = loader.get_index_dataset(allGPU=0, batch_size=batch_size)
+    else:
+        train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, means, stds = loader.get_index_dataset(batch_size=batch_size)
+    
+
+    sensor_ids, sensor_id_to_ind, adj_mx = load_graph_data("data/pems_cali_adj_mat.pkl")
+    edge_index, edge_weight = adjacency_to_edge_index(adj_mx)
+    
+
+        
+    t_min, v_min = train(train_dataloader, val_dataloader, means, stds, edges, edge_weights, epochs, 12,11160,2, allGPU=allGPU, debug=debug)
+    t2 = time.time()
+    print(f"Runtime: {round(t2 - t1,2)}; Best Train MSE: {t_min}; Best Validation MSE: {v_min}")
+    
+if __name__ == "__main__":
+    main()

--- a/examples/indexBatching/pems_bay_main.py
+++ b/examples/indexBatching/pems_bay_main.py
@@ -1,13 +1,13 @@
-import time 
-import csv
-import argparse
 from torch_geometric_temporal.nn.recurrent import BatchedDCRNN as DCRNN
 from torch_geometric_temporal.dataset import PemsBayDatasetLoader
+
 import torch.nn as nn
 import torch.optim as optim
+
+import argparse
+import csv
 import os
-
-
+import time 
 from utils import *
 
 

--- a/examples/indexBatching/pems_bay_main.py
+++ b/examples/indexBatching/pems_bay_main.py
@@ -1,7 +1,5 @@
 from torch_geometric_temporal.nn.recurrent import BatchedDCRNN as DCRNN
 from torch_geometric_temporal.dataset import PemsBayDatasetLoader
-
-import torch.nn as nn
 import torch.optim as optim
 
 import argparse

--- a/examples/indexBatching/pems_bay_main.py
+++ b/examples/indexBatching/pems_bay_main.py
@@ -1,0 +1,148 @@
+import time 
+import csv
+import argparse
+from torch_geometric_temporal.nn.recurrent import BatchedDCRNN as DCRNN
+from torch_geometric_temporal.dataset import PemsBayDatasetLoader
+import torch.nn as nn
+import torch.optim as optim
+import os
+
+
+from utils import *
+
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="Demo of index batching with PemsBay dataset")
+
+    parser.add_argument(
+        "-e", "--epochs", type=int, default=100, help="The desired number of training epochs"
+    )
+    parser.add_argument(
+        "-bs", "--batch-size", type=int, default=64, help="The desired batch size"
+    )
+    parser.add_argument(
+        "-g", "--gpu", type=str, default="False", help="Should data be preprocessed and migrated directly to the GPU"
+    )
+    parser.add_argument(
+        "-d", "--debug", type=str, default="False", help="Print values for debugging"
+    )
+    return parser.parse_args()
+
+def train(train_dataloader, val_dataloader, mean, std, edge_index, edge_weight, epochs, seq_length, num_nodes, num_features, 
+          allGPU=False, debug=False):
+    
+    
+
+    # Move to GPU
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    edge_index = edge_index.to(device)
+    edge_weight = edge_weight.to(device)
+    
+    if allGPU == False:
+        mean = mean.to(device)
+        std = std.to(device)
+
+    # Initialize model
+    model = DCRNN(num_features, num_features, K=3).to(device)
+
+    # Define optimizer and loss function
+    optimizer = optim.Adam(model.parameters(), lr=0.001)
+
+    # Training loop
+    stats = []
+    min_t = 9999
+    min_v = 9999
+    for epoch in range(epochs):
+        # Training phase
+        model.train()
+        train_loss = 0.0
+        i = 1
+        total = len(train_dataloader)
+        t1 = time.time()
+        for batch in train_dataloader:
+            X_batch, y_batch = batch
+
+            if allGPU == False:
+                X_batch = X_batch.to(device).float()
+                y_batch = y_batch.to(device).float()
+            # Forward pass
+            outputs = model(X_batch, edge_index, edge_weight)  # Shape: (batch_size, seq_length, num_nodes, out_channels)
+
+            loss = masked_mae_loss((outputs * std) + mean, (y_batch * std) + mean)
+
+            # Backward pass
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+            train_loss += loss.item()
+            if debug:
+                print(f"Train Batch: {i}/{total}", end="\r")
+                i+=1
+        
+
+        train_loss /= len(train_dataloader)
+
+        # Validation phase
+        model.eval()
+        val_loss = 0.0
+        i = 0
+        if debug:
+            print("                      ", end="\r")
+        total = len(val_dataloader)
+        with torch.no_grad():
+            for batch in val_dataloader:
+                X_batch, y_batch = batch
+
+                if allGPU == False:
+                    X_batch = X_batch.to(device).float()
+                    y_batch = y_batch.to(device).float()
+
+                # Forward pass
+                outputs = model(X_batch, edge_index, edge_weight)
+
+                # Calculate loss
+                loss = masked_mae_loss((outputs * std) + mean, (y_batch * std) + mean)
+                val_loss += loss.item()
+                if debug:
+                    print(f"Val Batch: {i}/{total}", end="\r")
+                    i += 1
+
+        val_loss /= len(val_dataloader)
+        t2 = time.time()
+        # Print epoch metrics
+        print(f"Epoch {epoch + 1}/{epochs}, Runtime: {t2 - t1}, Train Loss: {train_loss:.4f}, Val Loss: {val_loss:.4f}", flush=True)
+        stats.append([epoch+1, t2 - t1, train_loss, val_loss])
+
+        min_t = min(min_t, train_loss)
+        min_v = min(min_v, val_loss)
+
+
+    
+    return min_t, min_v
+
+def main():
+  
+
+
+    args = parse_arguments()
+    allGPU = args.gpu.lower() in ["true", "y", "t", "yes"]
+    debug = args.debug.lower() in ["true", "y", "t", "yes"]
+    batch_size = args.batch_size
+    epochs = args.epochs
+    t1 = time.time()
+    loader = PemsBayDatasetLoader(index=True)
+       
+    if allGPU == True:
+        train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, mean, std = loader.get_index_dataset(allGPU=0) 
+    else:
+        train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, mean, std = loader.get_index_dataset() 
+    
+    t_min, v_min = train(train_dataloader, val_dataloader, mean, std, edges, edge_weights, epochs, 12,325,2, allGPU=allGPU,debug=debug)
+    t2 = time.time()
+    print(f"Runtime: {round(t2 - t1,2)}; Best Train MSE: {t_min}; Best Validation MSE: {v_min}")
+
+   
+if __name__ == "__main__":
+    main()

--- a/examples/indexBatching/pems_bay_main.py
+++ b/examples/indexBatching/pems_bay_main.py
@@ -133,9 +133,9 @@ def main():
     loader = PemsBayDatasetLoader(index=True)
        
     if allGPU == True:
-        train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, mean, std = loader.get_index_dataset(allGPU=0) 
+        train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, mean, std = loader.get_index_dataset(allGPU=0, batch_size=batch_size) 
     else:
-        train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, mean, std = loader.get_index_dataset() 
+        train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, mean, std = loader.get_index_dataset(batch_size=batch_size) 
     
     t_min, v_min = train(train_dataloader, val_dataloader, mean, std, edges, edge_weights, epochs, 12,325,2, allGPU=allGPU,debug=debug)
     t2 = time.time()

--- a/examples/indexBatching/pems_ddp.py
+++ b/examples/indexBatching/pems_ddp.py
@@ -52,7 +52,7 @@ def parse_arguments():
     return parser.parse_args()
 
 
-def train(args=None, epochs=None, batch_size=None, allGPU=False, debug=False, loader=None):
+def train(args=None, epochs=None, batch_size=None, allGPU=False, debug=False, loader=None, start_time=None):
 
     worker_rank = int(dist.get_rank())
     gpu = worker_rank % 4   
@@ -166,6 +166,8 @@ def train(args=None, epochs=None, batch_size=None, allGPU=False, debug=False, lo
 
             min_t = min(min_t, train_loss)
             min_v = min(min_v, val_loss)
+    if worker_rank == 0:
+        print(f"Runtime: {round(t2 - start_time,2)}; Best Train MSE: {min_t}; Best Validation MSE: {min_v}", flush=True)
 
 def main():
     args = parse_arguments()
@@ -195,6 +197,7 @@ def main():
 
     futures = dispatch.run(client, train,
                             args=args, debug=debug, epochs=epochs, batch_size=batch_size,allGPU=allGPU,loader=loader,
+                            start_time=t1,
                             backend="gloo")
     
     key = uuid.uuid4().hex

--- a/examples/indexBatching/pems_ddp.py
+++ b/examples/indexBatching/pems_ddp.py
@@ -1,0 +1,207 @@
+import time 
+import csv
+import argparse
+import uuid
+import os
+
+from torch_geometric_temporal.nn.recurrent import BatchedDCRNN as DCRNN
+from torch_geometric_temporal.dataset import PemsBayDatasetLoader,PemsDatasetLoader
+from utils import *
+
+import torch
+import torch.optim as optim
+import torch.distributed as dist
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+
+from dask.distributed import LocalCluster
+from dask.distributed import Client
+from dask_pytorch_ddp import dispatch, results
+from dask.distributed import wait as Wait
+
+
+def parse_arguments():
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description="Demo of DDP index-batching with PeMS-Bay, PeMS-All-LA, and PeMS")
+
+    parser.add_argument(
+        "-e", "--epochs", type=int, default=100, help="The desired number of training epochs"
+    )
+    parser.add_argument(
+        "-bs", "--batch-size", type=int, default=64, help="The desired batch size"
+    )
+    parser.add_argument(
+        "-g", "--gpu", type=str, default="False", help="Should data be preprocessed and migrated directly to the GPU"
+    )
+    parser.add_argument(
+        "-d", "--debug", type=str, default="False", help="Print values for debugging"
+    )
+
+    parser.add_argument(
+     "--dask-cluster-file", type=str, default="", help="Dask scheduler file for the Dask CLI Interfance"
+    )
+
+    parser.add_argument(
+     "-np","--npar", type=int, default=1, help="The number of GPUs/workers per node"
+    )
+    parser.add_argument(
+     "--dataset", type=str, default="pems-bay", help="Which dataset is in use"
+    )
+
+    
+    return parser.parse_args()
+
+
+def train(args=None, epochs=None, batch_size=None, allGPU=False, debug=False, loader=None):
+
+    worker_rank = int(dist.get_rank())
+    gpu = worker_rank % 4   
+    device = f"cuda:{gpu}"
+    torch.cuda.set_device(device)
+    world_size = dist.get_world_size()
+
+    
+    if allGPU == True:
+        train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, mean, std = loader.get_index_dataset(allGPU=gpu, batch_size=batch_size, world_size=world_size, ddp_rank=worker_rank) 
+    else:
+        train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, mean, std = loader.get_index_dataset(batch_size=batch_size, world_size=world_size, ddp_rank=worker_rank) 
+    
+
+    
+    # Move to GPU
+    edge_index = edges.to(device)
+    edge_weight = edge_weights.to(device)
+    
+    if allGPU == False:
+        mean = mean.to(device)
+        std = std.to(device)
+        
+    # Initialize model
+    model = DCRNN(2, 2, K=3).to(device)
+    model = DDP(model, gradient_as_bucket_view=True, device_ids=[device], output_device=[device])
+
+    # Define optimizer and loss function
+    optimizer = optim.Adam(model.parameters(), lr=0.001)
+
+
+    # Training loop
+    stats = []
+    min_t = 9999
+    min_v = 9999
+    for epoch in range(epochs):
+        train_dataloader.sampler.set_epoch(epoch)
+
+        # Training phase
+        model.train()
+        train_loss = 0.0
+        i = 1
+        total = len(train_dataloader)
+        t1 = time.time()
+        for batch in train_dataloader:
+
+            X_batch, y_batch = batch
+
+            if allGPU == False:
+                X_batch = X_batch.to(device).float()
+                y_batch = y_batch.to(device).float()
+
+            # Forward pass
+            outputs = model(X_batch, edge_index, edge_weight)  # Shape: (batch_size, seq_length, num_nodes, out_channels)
+
+            # Calculate loss (use only the first output channel, assuming it's the target)
+            loss = masked_mae_loss((outputs * std) + mean, (y_batch * std) + mean)
+
+            # Backward pass
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+            train_loss += loss.item()
+            
+            if debug and worker_rank == 0:
+                print(f"Train Batch: {i}/{total}", end="\r")
+                i+=1
+            
+        
+
+        train_loss /= len(train_dataloader)
+
+        # Validation phase
+        model.eval()
+        val_loss = 0.0
+        i = 0
+        if debug and worker_rank == 0:
+            print("                      ", end="\r")
+        total = len(val_dataloader)
+        with torch.no_grad():
+            for batch in val_dataloader:
+                X_batch, y_batch = batch
+
+                if allGPU == False:
+                    X_batch = X_batch.to(device).float()
+                    y_batch = y_batch.to(device).float()
+
+                # Forward pass
+                outputs = model(X_batch, edge_index, edge_weight)
+
+                # Calculate loss
+                loss = masked_mae_loss((outputs * std) + mean, (y_batch * std) + mean)
+                val_loss += loss.item()
+                
+                if debug and worker_rank == 0:
+                    print(f"Val Batch: {i}/{total}", end="\r")
+                    i += 1
+
+        # average valdiation across all ranks
+        val_tensor = torch.tensor([val_loss, len(val_dataloader)])
+        dist.reduce(val_tensor,dst=0, op=dist.ReduceOp.SUM)
+        t2 = time.time()
+        
+        if worker_rank == 0:
+            val_loss = val_tensor[0]/ val_tensor[1]
+            
+            # Print epoch metrics
+            print(f"Epoch {epoch + 1}/{epochs}, Runtime: {t2 - t1}, Train Loss: {train_loss:.4f}, Val Loss: {val_loss:.4f}", flush=True)
+            stats.append([epoch+1, t2 - t1, train_loss, float(val_loss)])
+
+            min_t = min(min_t, train_loss)
+            min_v = min(min_v, val_loss)
+
+def main():
+    args = parse_arguments()
+    allGPU = args.gpu.lower() in ["true", "y", "t", "yes"]
+    debug = args.debug.lower() in ["true", "y", "t", "yes"]
+    batch_size = args.batch_size
+    epochs = args.epochs
+    npar = args.npar
+
+    if args.dataset.lower() not in ["pems-bay","pems"]:
+        raise ValueError("Invalid argument for --dataset. --dataset must be 'pems-bay' or 'pems'")
+  
+    t1 = time.time() 
+    
+    # force the datasets to download before launching dask cluster
+    if args.dataset.lower() == "pems-bay":
+        loader = PemsBayDatasetLoader(index=True)
+    if args.dataset.lower() == "pems":
+        loader = PemsDatasetLoader(index=True)
+    
+    
+    if args.dask_cluster_file != "":
+        client = Client(scheduler_file = args.dask_cluster_file)
+    else:
+        cluster = LocalCluster(n_workers=npar)
+        client = Client(cluster)
+
+    futures = dispatch.run(client, train,
+                            args=args, debug=debug, epochs=epochs, batch_size=batch_size,allGPU=allGPU,loader=loader,
+                            backend="gloo")
+    
+    key = uuid.uuid4().hex
+    rh = results.DaskResultsHandler(key)
+    rh.process_results(".", futures, raise_errors=False)
+    client.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/indexBatching/pems_ddp.py
+++ b/examples/indexBatching/pems_ddp.py
@@ -5,7 +5,7 @@ import uuid
 import os
 
 from torch_geometric_temporal.nn.recurrent import BatchedDCRNN as DCRNN
-from torch_geometric_temporal.dataset import PemsBayDatasetLoader,PemsDatasetLoader
+from torch_geometric_temporal.dataset import PemsBayDatasetLoader,PemsAllLADatasetLoader,PemsDatasetLoader
 from utils import *
 
 import torch
@@ -177,14 +177,16 @@ def main():
     epochs = args.epochs
     npar = args.npar
 
-    if args.dataset.lower() not in ["pems-bay","pems"]:
-        raise ValueError("Invalid argument for --dataset. --dataset must be 'pems-bay' or 'pems'")
+    if args.dataset.lower() not in ["pems-bay","pemsallla", "pems"]:
+        raise ValueError("Invalid argument for --dataset. --dataset must be 'pems-bay', 'pemsAllLA', or 'pems'")
   
     t1 = time.time() 
     
     # force the datasets to download before launching dask cluster
     if args.dataset.lower() == "pems-bay":
         loader = PemsBayDatasetLoader(index=True)
+    if args.dataset.lower() == "pemsallla":
+        loader = PemsAllLADatasetLoader(index=True)
     if args.dataset.lower() == "pems":
         loader = PemsDatasetLoader(index=True)
     

--- a/examples/indexBatching/pems_main.py
+++ b/examples/indexBatching/pems_main.py
@@ -139,12 +139,7 @@ def main():
     else:
         train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, means, stds = loader.get_index_dataset(batch_size=batch_size)
     
-
-    sensor_ids, sensor_id_to_ind, adj_mx = load_graph_data("data/pems_cali_adj_mat.pkl")
-    edge_index, edge_weight = adjacency_to_edge_index(adj_mx)
-    
-
-        
+       
     t_min, v_min = train(train_dataloader, val_dataloader, means, stds, edges, edge_weights, epochs, 12,11160,2, allGPU=allGPU, debug=debug)
     t2 = time.time()
     print(f"Runtime: {round(t2 - t1,2)}; Best Train MSE: {t_min}; Best Validation MSE: {v_min}")

--- a/examples/indexBatching/pems_main.py
+++ b/examples/indexBatching/pems_main.py
@@ -119,11 +119,6 @@ def train(train_dataloader, val_dataloader, mean, std, edges, edge_weights, epoc
 
         min_t = min(min_t, train_loss)
         min_v = min(min_v, val_loss)
-
-    with open("per_epoch_stats.csv", mode="w", newline="") as file:
-        writer = csv.writer(file)
-        writer.writerow(["epoch","runtime","t_mae", "v_mae"])
-        writer.writerows(stats)
     
     return min_t, min_v
 

--- a/examples/indexBatching/pems_main.py
+++ b/examples/indexBatching/pems_main.py
@@ -142,6 +142,7 @@ def main():
     batch_size = args.batch_size
     epochs = args.epochs
 
+    t1 = time.time()
     loader = PemsDatasetLoader(index=True)
     if allGPU:
         train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, means, stds = loader.get_index_dataset(allGPU=0)
@@ -155,7 +156,8 @@ def main():
 
         
     t_min, v_min = train(train_dataloader, val_dataloader, means, stds, edges, edge_weights, epochs, 12,11160,2, allGPU=allGPU, debug=debug)
-    train_t2 = time.time()
+    t2 = time.time()
+    print(f"Runtime: {round(t2 - t1,2)}; Best Train MSE: {t_min}; Best Validation MSE: {v_min}")
     
 if __name__ == "__main__":
     main()

--- a/examples/indexBatching/pems_main.py
+++ b/examples/indexBatching/pems_main.py
@@ -140,9 +140,9 @@ def main():
     t1 = time.time()
     loader = PemsDatasetLoader(index=True)
     if allGPU:
-        train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, means, stds = loader.get_index_dataset(allGPU=0)
+        train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, means, stds = loader.get_index_dataset(allGPU=0, batch_size=batch_size)
     else:
-        train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, means, stds = loader.get_index_dataset()
+        train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, means, stds = loader.get_index_dataset(batch_size=batch_size)
     
 
     sensor_ids, sensor_id_to_ind, adj_mx = load_graph_data("data/pems_cali_adj_mat.pkl")

--- a/examples/indexBatching/pems_main.py
+++ b/examples/indexBatching/pems_main.py
@@ -1,17 +1,14 @@
-import time 
-import csv
-
 from torch_geometric_temporal.nn.recurrent import BatchedDCRNN as DCRNN
 from torch_geometric_temporal.dataset import PemsDatasetLoader
 
-from torch.utils.data import DataLoader, TensorDataset
 import torch.nn as nn
 import torch.optim as optim
-import argparse
 
-from utils import *
-import threading
+import argparse
+import csv
 import os
+import time 
+from utils import *
 
 
 def parse_arguments():

--- a/examples/indexBatching/pems_main.py
+++ b/examples/indexBatching/pems_main.py
@@ -1,0 +1,161 @@
+import time 
+import csv
+
+from torch_geometric_temporal.nn.recurrent import BatchedDCRNN as DCRNN
+from torch_geometric_temporal.dataset import PemsDatasetLoader
+
+from torch.utils.data import DataLoader, TensorDataset
+import torch.nn as nn
+import torch.optim as optim
+import argparse
+
+from utils import *
+import threading
+import os
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="Demo of index batching with Pems dataset")
+
+    parser.add_argument(
+        "-e", "--epochs", type=int, default=30, help="The desired number of training epochs"
+    )
+    parser.add_argument(
+        "-bs", "--batch-size", type=int, default=64, help="The desired batch size"
+    )
+    parser.add_argument(
+        "-g", "--gpu", type=str, default="False", help="Should data be preprocessed and migrated directly to the GPU"
+    )
+    parser.add_argument(
+        "-d", "--debug", type=str, default="False", help="Print values for debugging"
+    )
+    return parser.parse_args()
+
+
+
+
+def train(train_dataloader, val_dataloader, mean, std, edges, edge_weights, epochs, seq_length, num_nodes, num_features, allGPU=False, debug=False):
+    
+    # Move to GPU
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    edge_index = edges.to(device)
+    edge_weight = edge_weights.to(device)
+    
+    if allGPU == False:
+        mean = mean.to(device)
+        std = std.to(device)
+
+    # Initialize model
+    model = DCRNN(num_features, num_features, K=3).to(device)
+
+    # Define optimizer and loss function
+    optimizer = optim.Adam(model.parameters(), lr=0.001)
+
+    # Training loop
+    stats = []
+    min_t = 9999
+    min_v = 9999
+    for epoch in range(epochs):
+        # Training phase
+        model.train()
+        train_loss = 0.0
+        i = 1
+        total = len(train_dataloader)
+        t1 = time.time()
+        for batch in train_dataloader:
+            X_batch, y_batch = batch
+
+            if allGPU == False:
+                # print("casting")
+                X_batch = X_batch.to(device).float()
+                y_batch = y_batch.to(device).float()
+
+            # Forward pass
+            outputs = model(X_batch, edge_index, edge_weight)  # Shape: (batch_size, seq_length, num_nodes, out_channels)
+
+            # Calculate loss (use only the first output channel, assuming it's the target)
+            loss = masked_mae_loss((outputs * std) + mean, (y_batch * std) + mean)
+
+            # Backward pass
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+            train_loss += loss.item()
+            if debug:
+                print(f"Train Batch: {i}/{total}", end="\r")
+                i+=1
+            # break
+        
+
+        train_loss /= len(train_dataloader)
+
+        # Validation phase
+        model.eval()
+        val_loss = 0.0
+        i = 0
+        if debug:
+            print("                      ", end="\r")
+        total = len(val_dataloader)
+        with torch.no_grad():
+            for batch in val_dataloader:
+                X_batch, y_batch = batch
+
+                if allGPU == False:
+                    X_batch = X_batch.to(device).float()
+                    y_batch = y_batch.to(device).float()
+
+                # Forward pass
+                outputs = model(X_batch, edge_index, edge_weight)
+
+                # Calculate loss
+                loss = masked_mae_loss((outputs * std) + mean, (y_batch * std) + mean)
+                val_loss += loss.item()
+                if debug:
+                    print(f"Val Batch: {i}/{total}", end="\r")
+                    i += 1
+                
+
+        val_loss /= len(val_dataloader)
+        t2 = time.time()
+        # Print epoch metrics
+        print(f"Epoch {epoch + 1}/{epochs}, Runtime: {t2 - t1}, Train Loss: {train_loss:.4f}, Val Loss: {val_loss:.4f}", flush=True)
+        stats.append([epoch+1, t2 - t1, train_loss, val_loss])
+
+        min_t = min(min_t, train_loss)
+        min_v = min(min_v, val_loss)
+
+    with open("per_epoch_stats.csv", mode="w", newline="") as file:
+        writer = csv.writer(file)
+        writer.writerow(["epoch","runtime","t_mae", "v_mae"])
+        writer.writerows(stats)
+    
+    return min_t, min_v
+
+def main():
+  
+
+
+    args = parse_arguments()
+    allGPU = args.gpu.lower() in ["true", "y", "t", "yes"]
+    debug = args.debug.lower() in ["true", "y", "t", "yes"]
+    batch_size = args.batch_size
+    epochs = args.epochs
+
+    loader = PemsDatasetLoader(index=True)
+    if allGPU:
+        train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, means, stds = loader.get_index_dataset(allGPU=0)
+    else:
+        train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, means, stds = loader.get_index_dataset()
+    
+
+    sensor_ids, sensor_id_to_ind, adj_mx = load_graph_data("data/pems_cali_adj_mat.pkl")
+    edge_index, edge_weight = adjacency_to_edge_index(adj_mx)
+    
+
+        
+    t_min, v_min = train(train_dataloader, val_dataloader, means, stds, edges, edge_weights, epochs, 12,11160,2, allGPU=allGPU, debug=debug)
+    train_t2 = time.time()
+    
+if __name__ == "__main__":
+    main()

--- a/examples/indexBatching/pems_main.py
+++ b/examples/indexBatching/pems_main.py
@@ -1,7 +1,5 @@
 from torch_geometric_temporal.nn.recurrent import BatchedDCRNN as DCRNN
 from torch_geometric_temporal.dataset import PemsDatasetLoader
-
-import torch.nn as nn
 import torch.optim as optim
 
 import argparse

--- a/examples/indexBatching/submit.sh
+++ b/examples/indexBatching/submit.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#PBS -l select=5:system=polaris
+#PBS -l place=scatter
+#PBS -l filesystems=home:eagle
+#PBS -l walltime=00:30:00
+#PBS -q <queue>
+#PBS -A <account>
+#PBS -o train.out
+#PBS -e train.err
+
+nodes=4
+gpus_per_node=4
+
+# should the training utilize GPU-index-batching
+allGPU=True
+
+# which dataset to train on; valid options include "pems-bay", 'pemsAllLA', and "pems"
+dataset="pems"
+
+# total workers
+total=$((gpus_per_node * nodes))
+
+readarray -t all_nodes < "$NODEFILE"
+
+# use first node for dask scheduler and client
+scheduler_node=${all_nodes[0]}
+monitor_node=${all_nodes[1]}
+
+# all nodes but first for workers
+tail -n +2 $NODEFILE > worker_nodefile.txt
+
+echo "Launching scheduler"
+mpiexec -n 1 --ppn 1 --cpu-bind none --hosts $scheduler_node dask scheduler --scheduler-file cluster.info &
+scheduler_pid=$!
+
+# wait for the scheduler to generate the cluster config file
+while ! [ -f cluster.info ]; do
+    sleep 1
+    echo .
+done
+
+echo "$total workers launching" 
+mpiexec -n $total --ppn $gpus_per_node --cpu-bind none --hostfile worker_nodefile.txt dask worker --local-directory /local/scratch --scheduler-file cluster.info --nthreads 8 --memory-limit 512GB &
+
+# give workers a bit to launch
+sleep 5
+
+echo "Launching client"
+mpiexec -n 1 --ppn 1 --cpu-bind none --hosts $scheduler_node `which python3` pems_ddp.py --dask-cluster-file cluster.info -np $gpus_per_node -g $allGPU --dataset $dataset

--- a/examples/indexBatching/utils.py
+++ b/examples/indexBatching/utils.py
@@ -1,0 +1,170 @@
+import pickle
+import torch
+import numpy as np
+import pandas as pd
+import csv
+import os
+import time
+import scipy.sparse as sp
+
+def masked_mae_loss(y_pred, y_true):
+
+    mask = (y_true != 0).float()
+    mask /= mask.mean()
+    loss = torch.abs(y_pred - y_true)
+    loss = loss * mask
+    # trick for nans: https://discuss.pytorch.org/t/how-to-set-nan-in-tensor-to-0/3918/3
+    loss[loss != loss] = 0
+    return loss.mean() 
+
+
+
+def load_graph_data(pkl_filename):
+    sensor_ids, sensor_id_to_ind, adj_mx = load_pickle(pkl_filename)
+    return sensor_ids, sensor_id_to_ind, adj_mx
+
+
+def load_pickle(pickle_file):
+    try:
+        with open(pickle_file, 'rb') as f:
+            pickle_data = pickle.load(f)
+    except UnicodeDecodeError as e:
+        with open(pickle_file, 'rb') as f:
+            pickle_data = pickle.load(f, encoding='latin1')
+    except Exception as e:
+        print('Unable to load data ', pickle_file, ':', e)
+        raise
+    return pickle_data
+
+def adjacency_to_edge_index(adj_mx):
+    """
+    Convert an adjacency matrix to edge_index and edge_weight.
+    Args:
+        adj_mx (np.ndarray): Adjacency matrix of shape (num_nodes, num_nodes).
+    Returns:
+        edge_index (torch.LongTensor): Shape (2, num_edges), source and target nodes.
+        edge_weight (torch.FloatTensor): Shape (num_edges,), edge weights.
+    """
+    # Convert to sparse matrix
+    adj_sparse = sp.coo_matrix(adj_mx)
+
+    # Extract edge indices and weights
+    edge_index = torch.tensor(
+        np.vstack((adj_sparse.row, adj_sparse.col)), dtype=torch.long
+    )
+    edge_weight = torch.tensor(adj_sparse.data, dtype=torch.float)
+
+    return edge_index, edge_weight
+
+# standard approach: see https://github.com/chnsh/DCRNN_PyTorch
+def benchmark_preprocess(h5File, dataset, key=None):
+
+    if "pems" in dataset.lower():
+        df = pd.read_hdf(h5File)
+
+        x_offsets = np.sort(
+            # np.concatenate(([-week_size + 1, -day_size + 1], np.arange(-11, 1, 1)))
+            np.concatenate((np.arange(-11, 1, 1),))
+        )
+        # Predict the next one hour
+        y_offsets = np.sort(np.arange(1, 13, 1))
+        num_samples, num_nodes = df.shape
+
+        data = np.expand_dims(df.values, axis=-1)
+        data_list = [data]
+        add_time_in_day= True
+        if add_time_in_day:
+            time_ind = (df.index.values - df.index.values.astype("datetime64[D]")) / np.timedelta64(1, "D")
+            time_in_day = np.tile(time_ind, [1, num_nodes, 1]).transpose((2, 1, 0))
+            data_list.append(time_in_day)
+
+        data = np.concatenate(data_list, axis=-1)
+
+
+        x, y = [], []
+        # t is the index of the last observation.
+        min_t = abs(min(x_offsets))
+        max_t = abs(num_samples - abs(max(y_offsets)))  # Exclusive
+        for t in range(min_t, max_t):
+            x_t = data[t + x_offsets, ...]
+
+            
+            y_t = data[t + y_offsets, ...]
+            x.append(x_t)
+            y.append(y_t)
+
+
+
+        x = np.stack(x, axis=0)
+        y = np.stack(y, axis=0)
+
+        return torch.tensor(x,dtype=torch.float),torch.tensor(y,dtype=torch.float)
+
+def collect_metrics():
+    import psutil
+    from pynvml import nvmlInit, nvmlDeviceGetHandleByIndex, nvmlDeviceGetMemoryInfo, nvmlShutdown
+    
+    try:
+        # Initialize NVML for GPU metrics
+        nvmlInit()
+
+        # Open the CSV file in append mode
+        
+        data = []
+        max_gpu_mem = -1
+        max_system_mem = -1
+        while True:
+            # Collect system memory usage
+            timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
+            mem = psutil.virtual_memory()
+            total_rss = sum(proc.memory_info().rss for proc in psutil.process_iter(attrs=['memory_info']))
+            system_memory_used = total_rss / (1024**2)  # Convert to MB
+            system_memory_total = mem.total / (1024**2)  # Convert to MB
+
+            # Collect GPU memory usage
+            gpu_metrics = []
+            handle = nvmlDeviceGetHandleByIndex(0)
+            info = nvmlDeviceGetMemoryInfo(handle)
+            gpu_memory_used = info.used / (1024**2)  # Convert to MB
+            gpu_memory_total = info.total / (1024**2)  # Convert to MB
+
+            max_gpu_mem = max(gpu_memory_used, max_gpu_mem)
+            max_system_mem = max(system_memory_used, max_system_mem)
+            data.append([timestamp,system_memory_used,system_memory_total, gpu_memory_used, gpu_memory_total])
+            
+            if os.path.isfile("flag.txt"):
+                os.remove("flag.txt")
+                break
+
+            if os.path.isfile("stats.csv"):
+                with open("system_stats.csv", mode="w", newline="") as f:
+                    writer = csv.writer(f)
+
+                    # Write headers to the CSV file
+                    headers = [
+                        "Timestamp",
+                        "System_Memory_Used",
+                        "System_Memory_Total",
+                        "GPU_Memory_Used",
+                        "GPU_Memory_Total"
+                    ]
+                    writer.writerow(headers)
+                    writer.writerows(data)
+
+                    
+                df = pd.read_csv("stats.csv")
+                df['system_memory_total'] = system_memory_total
+                df['max_system_mem'] = max_system_mem
+                df['gpu_memory_total'] = gpu_memory_total
+                df['max_gpu_mem'] = max_gpu_mem
+                
+                df.to_csv("stats.csv", index=False)
+                break
+            time.sleep(1)
+
+    except Exception as e:
+        print("Error in collecting metrics:", str(e))
+
+    finally:
+        # Shutdown NVML
+        nvmlShutdown()

--- a/examples/indexBatching/windmill_main.py
+++ b/examples/indexBatching/windmill_main.py
@@ -1,0 +1,154 @@
+from torch_geometric_temporal.nn.recurrent import BatchedDCRNN as DCRNN
+from torch_geometric_temporal.dataset import WindmillOutputLargeDatasetLoader
+import torch.optim as optim
+
+import argparse
+import time 
+import csv
+import os
+from utils import *
+
+
+
+def parse_arguments():
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description="Demo of index batching with WindmillLarge dataset")
+
+    parser.add_argument(
+        "-e", "--epochs", type=int, default=100, help="The desired number of training epochs"
+    )
+    parser.add_argument(
+        "-bs", "--batch-size", type=int, default=64, help="The desired batch size"
+    )
+    parser.add_argument(
+        "-m", "--mode", type=str, default="base", help="Which version to run"
+    )
+    parser.add_argument(
+        "-g", "--gpu", type=str, default="False", help="Should data be preprocessed and migrated directly to the GPU"
+    )
+    parser.add_argument(
+        "-d", "--debug", type=str, default="False", help="Print values for debugging"
+    )
+    
+    return parser.parse_args()
+
+
+def train(train_dataloader, val_dataloader, mean, std, edge_index,edge_weight, epochs, seq_length, num_nodes, num_features, 
+            allGPU=False, debug=False):
+    
+
+    # Move to GPU
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    edge_index = edge_index.to(device)
+    edge_weight = edge_weight.to(device)
+    
+    if allGPU == False:
+        mean = mean.to(device)
+        std = std.to(device)
+
+    # Initialize model
+    model = DCRNN(num_features, num_features, K=3).to(device)
+
+    # Define optimizer and loss function
+    optimizer = optim.Adam(model.parameters(), lr=0.001)
+
+    # Training loop
+    stats = []
+    min_t = 9999
+    min_v = 9999
+    for epoch in range(epochs):
+        # Training phase
+        model.train()
+        train_loss = 0.0
+        i = 1
+        total = len(train_dataloader)
+        t1 = time.time()
+        for batch in train_dataloader:
+            X_batch, y_batch = batch
+
+            if allGPU == False:
+                # print("casting")
+                X_batch = X_batch.to(device).float()
+                y_batch = y_batch.to(device).float()
+
+            # Forward pass
+            outputs = model(X_batch, edge_index, edge_weight)  # Shape: (batch_size, seq_length, num_nodes, out_channels)
+
+            # Calculate loss (use only the first output channel, assuming it's the target)
+            loss = masked_mae_loss((outputs * std) + mean, (y_batch * std) + mean)
+           
+            # Backward pass
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+            train_loss += loss.item()
+            if debug:
+                print(f"Train Batch: {i}/{total}", end="\r")
+                i+=1
+           
+        
+
+        train_loss /= len(train_dataloader)
+
+        # Validation phase
+        model.eval()
+        val_loss = 0.0
+        i = 0
+        if debug:
+            print("                      ", end="\r")
+        total = len(val_dataloader)
+        with torch.no_grad():
+            for batch in val_dataloader:
+                X_batch, y_batch = batch
+
+                if allGPU == False:
+                    X_batch = X_batch.to(device).float()
+                    y_batch = y_batch.to(device).float()
+
+                # Forward pass
+                outputs = model(X_batch, edge_index, edge_weight)
+
+                # Calculate loss
+                loss = masked_mae_loss((outputs * std) + mean, (y_batch * std) + mean)
+                val_loss += loss.item()
+                
+                if debug:
+                    print(f"Val Batch: {i}/{total}", end="\r")
+                    i += 1
+
+        val_loss /= len(val_dataloader)
+        t2 = time.time()
+        
+        # Print epoch metrics
+        print(f"Epoch {epoch + 1}/{epochs}, Runtime: {t2 - t1}, Train Loss: {train_loss:.4f}, Val Loss: {val_loss:.4f}", flush=True)
+        stats.append([epoch+1, t2 - t1, train_loss, val_loss])
+
+        min_t = min(min_t, train_loss)
+        min_v = min(min_v, val_loss)
+
+    return min_t, min_v
+
+def main():
+
+    args = parse_arguments()
+    allGPU = args.gpu.lower() in ["true", "y", "t"]
+    debug = args.debug.lower() in ["true", "y", "t"]
+    batch_size = args.batch_size
+    epochs = args.epochs
+    
+    t1 = time.time()
+    loader = WindmillOutputLargeDatasetLoader()
+    if allGPU == True:
+        train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, mean, std = loader.get_index_dataset(allGPU=0, batch_size=batch_size)
+    else:
+        train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, mean, std = loader.get_index_dataset(batch_size=batch_size)
+  
+    
+    
+    t_min, v_min = train(train_dataloader, val_dataloader, mean, std, edges, edge_weights, epochs, 8,319,1, allGPU=allGPU, debug=debug)
+    t2 = time.time()
+    print(f"Runtime: {round(t2 - t1,2)}; Best Train MSE: {t_min}; Best Validation MSE: {v_min}")
+    
+if __name__ == "__main__":
+    main()

--- a/examples/indexBatching/windmill_main.py
+++ b/examples/indexBatching/windmill_main.py
@@ -138,7 +138,7 @@ def main():
     epochs = args.epochs
     
     t1 = time.time()
-    loader = WindmillOutputLargeDatasetLoader()
+    loader = WindmillOutputLargeDatasetLoader(index=True)
     if allGPU == True:
         train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, mean, std = loader.get_index_dataset(allGPU=0, batch_size=batch_size)
     else:

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ install_requires = [
 ]
 tests_require = ["pytest", "pytest-cov", "mock", "networkx", "tqdm"]
 index_require = ['dask', "pandas", "tables"]
+ddp_require = ["dask[distributed]", "dask_pytorch_ddp", "pandas", "tables"]
+
 keywords = [
     "machine-learning",
     "deep-learning",
@@ -48,7 +50,8 @@ setup(
     install_requires=install_requires,
     extras_require={
         "test": tests_require,
-        "index": index_require
+        "index": index_require,
+        "ddp": ddp_require
     },
     python_requires=">=3.6",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,13 @@ install_requires = [
     "torch_scatter",
     "torch_geometric",
     "numpy",
-    "networkx",
-]
-tests_require = ["pytest", "pytest-cov", "mock", "networkx", "tqdm"]
+    "networkx"
+    ],
+extras_require = {
+    "test": ["pytest", "pytest-cov", "mock", "networkx", "tqdm"],
+    "index":['dask', "pandas"]
+}
+
 
 keywords = [
     "machine-learning",

--- a/setup.py
+++ b/setup.py
@@ -8,14 +8,10 @@ install_requires = [
     "torch_scatter",
     "torch_geometric",
     "numpy",
-    "networkx"
-    ],
-extras_require = {
-    "test": ["pytest", "pytest-cov", "mock", "networkx", "tqdm"],
-    "index":['dask', "pandas"]
-}
-
-
+    "networkx",
+]
+tests_require = ["pytest", "pytest-cov", "mock", "networkx", "tqdm"]
+index_require = ['dask', "pandas"]
 keywords = [
     "machine-learning",
     "deep-learning",
@@ -52,6 +48,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         "test": tests_require,
+        "index": index_require
     },
     python_requires=">=3.6",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
     "networkx",
 ]
 tests_require = ["pytest", "pytest-cov", "mock", "networkx", "tqdm"]
-index_require = ['dask', "pandas"]
+index_require = ['dask', "pandas", "tables"]
 keywords = [
     "machine-learning",
     "deep-learning",

--- a/torch_geometric_temporal/dataset/__init__.py
+++ b/torch_geometric_temporal/dataset/__init__.py
@@ -2,6 +2,7 @@ from .chickenpox import ChickenpoxDatasetLoader
 from .pedalme import PedalMeDatasetLoader
 from .metr_la import METRLADatasetLoader
 from .pems_bay import PemsBayDatasetLoader
+from .pemsAllLA import PemsAllLADatasetLoader
 from .pems import PemsDatasetLoader
 from .wikimath import WikiMathsDatasetLoader
 from .windmilllarge import WindmillOutputLargeDatasetLoader

--- a/torch_geometric_temporal/dataset/__init__.py
+++ b/torch_geometric_temporal/dataset/__init__.py
@@ -2,8 +2,6 @@ from .chickenpox import ChickenpoxDatasetLoader
 from .pedalme import PedalMeDatasetLoader
 from .metr_la import METRLADatasetLoader
 from .pems_bay import PemsBayDatasetLoader
-from .pemsAllLA import PemsAllLADatasetLoader
-from .pems import PemsDatasetLoader
 from .wikimath import WikiMathsDatasetLoader
 from .windmilllarge import WindmillOutputLargeDatasetLoader
 from .windmillmedium import WindmillOutputMediumDatasetLoader
@@ -12,3 +10,6 @@ from .encovid import EnglandCovidDatasetLoader
 from .twitter_tennis import TwitterTennisDatasetLoader
 from .montevideo_bus import MontevideoBusDatasetLoader
 from .mtm import MTMDatasetLoader
+
+from .pemsAllLA import PemsAllLADatasetLoader
+from .pems import PemsDatasetLoader

--- a/torch_geometric_temporal/dataset/__init__.py
+++ b/torch_geometric_temporal/dataset/__init__.py
@@ -2,6 +2,7 @@ from .chickenpox import ChickenpoxDatasetLoader
 from .pedalme import PedalMeDatasetLoader
 from .metr_la import METRLADatasetLoader
 from .pems_bay import PemsBayDatasetLoader
+from .pems import PemsDatasetLoader
 from .wikimath import WikiMathsDatasetLoader
 from .windmilllarge import WindmillOutputLargeDatasetLoader
 from .windmillmedium import WindmillOutputMediumDatasetLoader

--- a/torch_geometric_temporal/dataset/chickenpox.py
+++ b/torch_geometric_temporal/dataset/chickenpox.py
@@ -20,9 +20,11 @@ class ChickenpoxDatasetLoader(object):
 
     def __init__(self, index=False):
         self._read_web_data()
-        
-        if index:
+        self.index = index
+
+        if index == True:
             from ..signal import IndexDataset
+            self.IndexDataset = IndexDataset 
 
     def _read_web_data(self):
         url = "https://raw.githubusercontent.com/benedekrozemberczki/pytorch_geometric_temporal/master/dataset/chickenpox.json"
@@ -88,7 +90,8 @@ class ChickenpoxDatasetLoader(object):
             ]
         """
         
-        
+        if not self.index:
+            raise ValueError("get_index_dataset requires 'index=True' in the constructor.")
         data = np.array(self._dataset["FX"])
         edges = torch.tensor(self._dataset["edges"],dtype=torch.int64).T
         edge_weights = torch.ones(edges.shape[1],dtype=torch.float)
@@ -112,9 +115,9 @@ class ChickenpoxDatasetLoader(object):
         x_val = x_i[num_train: num_train + num_val]
         x_test = x_i[-num_test:]
 
-        train_dataset = IndexDataset(x_train,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
-        val_dataset = IndexDataset(x_val,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
-        test_dataset = IndexDataset(x_test,data,lags,gpu=not (allGPU == -1),lazy=dask_batching)
+        train_dataset = self.IndexDataset(x_train,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
+        val_dataset = self.IndexDataset(x_val,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
+        test_dataset = self.IndexDataset(x_test,data,lags,gpu=not (allGPU == -1),lazy=dask_batching)
         
         train_dataloader = DataLoader(train_dataset, batch_size=batch_size, shuffle=shuffle)
         val_dataloader = DataLoader(val_dataset, batch_size=batch_size, shuffle=shuffle)

--- a/torch_geometric_temporal/dataset/chickenpox.py
+++ b/torch_geometric_temporal/dataset/chickenpox.py
@@ -2,8 +2,8 @@ import json
 import ssl
 import urllib.request
 import numpy as np
-from torch.utils.data import DataLoader
 import torch
+from torch.utils.data import DataLoader
 
 from ..signal import StaticGraphTemporalSignal,IndexDataset
 

--- a/torch_geometric_temporal/dataset/chickenpox.py
+++ b/torch_geometric_temporal/dataset/chickenpox.py
@@ -23,7 +23,7 @@ class ChickenpoxDatasetLoader(object):
         self.index = index
 
         if index == True:
-            from ..signal import IndexDataset
+            from ..signal.index_dataset import IndexDataset
             self.IndexDataset = IndexDataset 
 
     def _read_web_data(self):

--- a/torch_geometric_temporal/dataset/chickenpox.py
+++ b/torch_geometric_temporal/dataset/chickenpox.py
@@ -5,7 +5,7 @@ import numpy as np
 import torch
 from torch.utils.data import DataLoader
 
-from ..signal import StaticGraphTemporalSignal,IndexDataset
+from ..signal import StaticGraphTemporalSignal
 
 
 class ChickenpoxDatasetLoader(object):
@@ -20,6 +20,9 @@ class ChickenpoxDatasetLoader(object):
 
     def __init__(self, index=False):
         self._read_web_data()
+        
+        if index:
+            from ..signal import IndexDataset
 
     def _read_web_data(self):
         url = "https://raw.githubusercontent.com/benedekrozemberczki/pytorch_geometric_temporal/master/dataset/chickenpox.json"

--- a/torch_geometric_temporal/dataset/chickenpox.py
+++ b/torch_geometric_temporal/dataset/chickenpox.py
@@ -81,8 +81,8 @@ class ChickenpoxDatasetLoader(object):
                 DataLoader,  # Dataloader for the training set
                 DataLoader,  # Dataloader for the validation set
                 DataLoader,  # Dataloader for the test set
-                np.ndarray,  # Edge indices (shape: [2, num_edges])
-                np.ndarray   # Edge weights (shape: [num_edges])
+                torch.tensor,  # Edge indices (shape: [2, num_edges])
+                torch.tensor   # Edge weights (shape: [num_edges])
             ]
         """
         
@@ -90,8 +90,8 @@ class ChickenpoxDatasetLoader(object):
             raise NotImplementedError("Currently dask batching is not implemented for the Chickenpox dataset")
 
         data = np.array(self._dataset["FX"])
-        edges = np.array(self._dataset["edges"]).T
-        edge_weights = np.ones(edges.shape[1])
+        edges = torch.tensor(self._dataset["edges"],dtype=torch.int64).T
+        edge_weights = torch.ones(edges.shape[1],dtype=torch.float)
         num_samples = data.shape[0]
         
         if allGPU != -1:

--- a/torch_geometric_temporal/dataset/chickenpox.py
+++ b/torch_geometric_temporal/dataset/chickenpox.py
@@ -63,7 +63,7 @@ class ChickenpoxDatasetLoader(object):
         )
         return dataset
     
-    def get_index_dataset(self, lags=4, batch_size=4, shuffle=False, allGPU=-1, ratio=(0.7, 0.1, 0.2)):
+    def get_index_dataset(self, lags=4, batch_size=4, shuffle=False, allGPU=-1, ratio=(0.7, 0.1, 0.2),dask_batching=False):
         """
         Returns torch dataloaders using index batching for Chickenpox Hungary dataset.
 

--- a/torch_geometric_temporal/dataset/chickenpox.py
+++ b/torch_geometric_temporal/dataset/chickenpox.py
@@ -16,8 +16,11 @@ class ChickenpoxDatasetLoader(object):
     chickenpox cases (we included 4 lags). The target is the weekly number of
     cases for the upcoming week (signed integers). Our dataset consist of more
     than 500 snapshots (weeks).
-    """
 
+    Args:
+        index (bool, optional): If True, initializes the dataloader to use index-based batching.
+            Defaults to False.
+    """
     def __init__(self, index=False):
         self._read_web_data()
         self.index = index
@@ -81,17 +84,19 @@ class ChickenpoxDatasetLoader(object):
             ratio (tuple of float, optional): The desired train, validation, and test split ratios, respectively.
 
         Returns:
-            Tuple[
-                DataLoader,  # Dataloader for the training set
-                DataLoader,  # Dataloader for the validation set
-                DataLoader,  # Dataloader for the test set
-                torch.tensor,  # Edge indices (shape: [2, num_edges])
-                torch.tensor   # Edge weights (shape: [num_edges])
-            ]
+            Tuple[torch.utils.data.DataLoader, torch.utils.data.DataLoader, torch.utils.data.DataLoader, torch.Tensor, torch.Tensor]: 
+            
+            A 5-tuple containing:
+                - **train_dataLoader** (*torch.utils.data.DataLoader*): Dataloader for the training set.
+                - **val_dataLoader** (*torch.utils.data.DataLoader*): Dataloader for the validation set.
+                - **test_dataLoader** (*torch.utils.data.DataLoader*): Dataloader for the test set.
+                - **edges** (*torch.Tensor*): The graph edges as a 2D matrix, shape `[2, num_edges]`.
+                - **edge_weights** (*torch.Tensor*): Each graph edge's weight, shape `[num_edges]`.
         """
         
         if not self.index:
             raise ValueError("get_index_dataset requires 'index=True' in the constructor.")
+        
         data = np.array(self._dataset["FX"])
         edges = torch.tensor(self._dataset["edges"],dtype=torch.int64).T
         edge_weights = torch.ones(edges.shape[1],dtype=torch.float)

--- a/torch_geometric_temporal/dataset/chickenpox.py
+++ b/torch_geometric_temporal/dataset/chickenpox.py
@@ -63,7 +63,7 @@ class ChickenpoxDatasetLoader(object):
         )
         return dataset
     
-    def get_index_dataset(self, lags=4, batch_size=4, shuffle=False, allGPU=-1, dask_batching=False, ratio=(0.7, 0.1, 0.2)):
+    def get_index_dataset(self, lags=4, batch_size=4, shuffle=False, allGPU=-1, ratio=(0.7, 0.1, 0.2)):
         """
         Returns torch dataloaders using index batching for Chickenpox Hungary dataset.
 
@@ -74,7 +74,6 @@ class ChickenpoxDatasetLoader(object):
             allGPU (int, optional): GPU device ID for performing preprocessing in GPU memory. 
                                     If -1, computation is done on CPU. Defaults to -1.
             ratio (tuple of float, optional): The desired train, validation, and test split ratios, respectively.
-            dask_batching (bool): Should dask batching be used
 
         Returns:
             Tuple[
@@ -86,9 +85,7 @@ class ChickenpoxDatasetLoader(object):
             ]
         """
         
-        if dask_batching:
-            raise NotImplementedError("Currently dask batching is not implemented for the Chickenpox dataset")
-
+        
         data = np.array(self._dataset["FX"])
         edges = torch.tensor(self._dataset["edges"],dtype=torch.int64).T
         edge_weights = torch.ones(edges.shape[1],dtype=torch.float)

--- a/torch_geometric_temporal/dataset/chickenpox.py
+++ b/torch_geometric_temporal/dataset/chickenpox.py
@@ -3,9 +3,10 @@ import ssl
 import urllib.request
 import numpy as np
 from torch.utils.data import DataLoader
+import torch
 
-from ..signal import StaticGraphTemporalSignal
-from ..signal import IndexDataset
+from ..signal import StaticGraphTemporalSignal,IndexDataset
+
 
 class ChickenpoxDatasetLoader(object):
     """A dataset of county level chicken pox cases in Hungary between 2004
@@ -17,7 +18,7 @@ class ChickenpoxDatasetLoader(object):
     than 500 snapshots (weeks).
     """
 
-    def __init__(self):
+    def __init__(self, index=False):
         self._read_web_data()
 
     def _read_web_data(self):
@@ -111,9 +112,9 @@ class ChickenpoxDatasetLoader(object):
         x_val = x_i[num_train: num_train + num_val]
         x_test = x_i[-num_test:]
 
-        train_dataset = IndexDataset(x_train,data,lags,gpu=allGPU, lazy=dask_batching)
-        val_dataset = IndexDataset(x_val,data,lags,gpu=allGPU, lazy=dask_batching)
-        test_dataset = IndexDataset(x_test,data,lags,gpu=allGPU,lazy=dask_batching)
+        train_dataset = IndexDataset(x_train,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
+        val_dataset = IndexDataset(x_val,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
+        test_dataset = IndexDataset(x_test,data,lags,gpu=not (allGPU == -1),lazy=dask_batching)
         
         train_dataloader = DataLoader(train_dataset, batch_size=batch_size, shuffle=shuffle)
         val_dataloader = DataLoader(val_dataset, batch_size=batch_size, shuffle=shuffle)

--- a/torch_geometric_temporal/dataset/pems.py
+++ b/torch_geometric_temporal/dataset/pems.py
@@ -9,6 +9,7 @@ from ..signal import StaticGraphTemporalSignal
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data import DataLoader
 import pickle
+from typing import Tuple
 
 class PemsDatasetLoader(object):
     """
@@ -22,7 +23,7 @@ class PemsDatasetLoader(object):
 
     def __init__(self, raw_data_dir=os.path.join(os.getcwd(), "data"),index=False):
         if not index:
-            NotImplementedError("The PeMS dataset does not support batching without  the index-method")
+            NotImplementedError("The PeMS dataset does not support batching without the index-method")
 
         else:
             from ..signal.index_dataset import IndexDataset
@@ -35,12 +36,6 @@ class PemsDatasetLoader(object):
         self.index = index
         self.raw_data_dir = raw_data_dir
         self._read_web_data()
-
-    def _download_url(self, url, save_path):  # pragma: no cover
-        context = ssl._create_unverified_context()
-        with urllib.request.urlopen(url, context=context) as dl_file:
-            with open(save_path, "wb") as out_file:
-                out_file.write(dl_file.read())
 
     def _read_web_data(self):  
         PeMS_file_links = {
@@ -66,10 +61,11 @@ class PemsDatasetLoader(object):
                     for chunk in response.iter_content(chunk_size=33554432):
                         file.write(chunk)
                         progress_bar.update(len(chunk))
-         
-    
-    def get_index_dataset(self, lags=12, batch_size=64, shuffle=False, allGPU=-1, ratio=(0.7, 0.1, 0.2), 
-                          world_size=-1, ddp_rank=-1, dask_batching=False):
+                 
+    def get_index_dataset(self, lags: int = 12, batch_size: int = 64, shuffle: bool = False, allGPU: int = -1, 
+                        ratio: Tuple[float, float, float] = (0.7, 0.1, 0.2), world_size: int =-1, ddp_rank: int = -1, 
+                        dask_batching: bool = False) -> Tuple[DataLoader, DataLoader, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+
         """
         Returns torch dataloaders using index batching for PeMS dataset.
 

--- a/torch_geometric_temporal/dataset/pems.py
+++ b/torch_geometric_temporal/dataset/pems.py
@@ -8,7 +8,6 @@ from torch_geometric.utils import dense_to_sparse
 from ..signal import StaticGraphTemporalSignal
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data import DataLoader
-import pandas as pd
 import pickle
 
 class PemsDatasetLoader(object):

--- a/torch_geometric_temporal/dataset/pems.py
+++ b/torch_geometric_temporal/dataset/pems.py
@@ -1,0 +1,162 @@
+import os
+import ssl
+import requests
+from tqdm import tqdm
+import numpy as np
+import torch
+from torch_geometric.utils import dense_to_sparse
+from ..signal import StaticGraphTemporalSignal,IndexDataset
+from torch.utils.data import DataLoader
+import pandas as pd
+import pickle
+
+class PemsDatasetLoader(object):
+    """A traffic forecasting dataset as described in Diffusion Convolution Layer Paper.
+
+    This traffic dataset is collected by California Transportation Agencies (CalTrans)
+    Performance Measurement System (PeMS). It is represented by a network of 325 traffic sensors
+    in the Bay Area with 6 months of traffic readings ranging from Jan 1st 2017 to May 31th 2017
+    in 5 minute intervals.
+
+    For details see: `"Diffusion Convolutional Recurrent Neural Network:
+    Data-Driven Traffic Forecasting" <https://arxiv.org/abs/1707.01926>`_
+    """
+
+    def __init__(self, raw_data_dir=os.path.join(os.getcwd(), "data"),index=False):
+        if not index:
+            NotImplementedError("The PeMS dataset does not support batching with the index-method")
+
+
+        super(PemsDatasetLoader, self).__init__()
+        self.index = index
+        self.raw_data_dir = raw_data_dir
+        self._read_web_data()
+
+    def _download_url(self, url, save_path):  # pragma: no cover
+        context = ssl._create_unverified_context()
+        with urllib.request.urlopen(url, context=context) as dl_file:
+            with open(save_path, "wb") as out_file:
+                out_file.write(dl_file.read())
+
+    def _read_web_data(self):  
+        PeMS_file_links = {
+            "pems_cali_distances.csv": "https://anl.app.box.com/shared/static/cfnc6wryh4yrp58qfc5z7tyxbbpj4gek",
+            "pems_cali_adj_mat.pkl" : "https://anl.app.box.com/shared/static/4143x1repqa1u26aiz7o2rvw3vpcu0wp",
+            "pems_cali_speed.h5": "https://anl.app.box.com/shared/static/7hfhtie02iufy75ac1d8g8530majwci0"
+        }          
+        
+
+        for key in PeMS_file_links.keys():
+            
+            # Check if file is in data folder from working directory, otherwise download
+            if not os.path.isfile(
+            os.path.join(self.raw_data_dir,key)
+            ):
+                print("Downloading ", key, flush=True)
+                
+                response = requests.get(PeMS_file_links[key], stream=True)
+                file_size = int(response.headers.get('content-length', 0))
+
+                with open(os.path.join(self.raw_data_dir, key), "wb") as file, tqdm(
+                    total=file_size, unit="B", unit_scale=True, unit_divisor=1024
+                ) as progress_bar:
+                    for chunk in response.iter_content(chunk_size=33554432):
+                        file.write(chunk)
+                        progress_bar.update(len(chunk))
+         
+    
+    def get_index_dataset(self, lags=12, batch_size=64, shuffle=False, allGPU=-1, dask_batching=False, ratio=(0.7, 0.1, 0.2)):
+        """
+        Returns torch dataloaders using index batching for Chickenpox Hungary dataset.
+
+        Args:
+            lags (int, optional): The number of time lags. Defaults to 12.
+            batch_size (int, optional): Batch size. Defaults to 64.
+            shuffle (bool, optional): If the data should be shuffled. Defaults to False.
+            allGPU (int, optional): GPU device ID for performing preprocessing in GPU memory. 
+                                    If -1, computation is done on CPU. Defaults to -1.
+            ratio (tuple of float, optional): The desired train, validation, and test split ratios, respectively.
+            dask_batching (bool): Should dask batching be used
+
+        Returns:
+            Tuple[
+                DataLoader,  # Dataloader for the training set
+                DataLoader,  # Dataloader for the validation set
+                DataLoader,  # Dataloader for the test set
+                torch.tensor,  # Edge indices (shape: [2, num_edges])
+                torch.tensor,   # Edge weights (shape: [num_edges])
+                torch.tensor,   # Means
+                torch.tensor,   # Stds
+            ]
+        """
+
+        # adj matrix setup
+        with open(os.path.join(self.raw_data_dir, "pems_cali_adj_mat.pkl"), 'rb') as f:
+            _, _, adj_mx = pickle.load(f)
+        edges, edge_weights = dense_to_sparse(torch.from_numpy(adj_mx))
+    
+        # setup data
+        df = pd.read_hdf(os.path.join(self.raw_data_dir, "pems_cali_speed.h5"), "df")
+        num_samples, num_nodes = df.shape
+        
+
+        
+        if allGPU != -1:
+            data = torch.empty((num_samples, num_nodes, 2), device='cuda',dtype=torch.float)
+            data[...,0] = torch.tensor(df.values).to(f"cuda:{allGPU}")
+            
+        else:
+            data = np.expand_dims(df.values, axis=-1)
+            data_list = [data[:]]
+
+
+        
+        if allGPU != -1:
+            time_ind = (df.index.values - df.index.values.astype("datetime64[D]")) / np.timedelta64(1, "D")
+            data[...,1] = torch.squeeze(torch.tensor(np.tile(time_ind, [1, num_nodes, 1]).transpose((2, 1, 0)))).to(f"cuda:{allGPU}")
+        else:
+            time_ind = (df.index.values - df.index.values.astype("datetime64[D]")) / np.timedelta64(1, "D")
+            time_in_day = np.tile(time_ind, [1, num_nodes, 1]).transpose((2, 1, 0))
+            data_list.append(time_in_day)
+        
+
+        # Normalise as in DCRNN paper (via Z-Score Method)
+        if allGPU != -1:
+            data = data.to(f"cuda:{allGPU}")
+            
+            means = torch.mean(data, dim=(0, 1), keepdim=True) 
+            stds = torch.std(data, dim=(0, 1), keepdim=True) 
+            data = (data - means) / stds
+            
+        else:
+            data = np.concatenate(data_list, axis=-1)
+            means = np.mean(data, axis=(0, 1))
+            stds = np.std(data, axis=(0, 1))
+            data = (data - means) / stds 
+            
+            means = torch.tensor(means,dtype=torch.float)
+            stds = torch.tensor(stds,dtype=torch.float)
+            
+        
+        num_samples = data.shape[0]
+        x_i = np.arange(num_samples - (2 * lags - 1))
+        num_samples = x_i.shape[0]
+        num_train = round(num_samples * ratio[0])
+        num_test = round(num_samples * ratio[2])
+        num_val = num_samples - num_train - num_test
+
+        x_train = x_i[:num_train]
+        x_val = x_i[num_train: num_train + num_val]
+        x_test = x_i[-num_test:]
+
+
+        train_dataset = IndexDataset(x_train,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
+        val_dataset = IndexDataset(x_val,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
+        test_dataset = IndexDataset(x_test,data,lags,gpu=not (allGPU == -1),lazy=dask_batching)
+        
+        train_dataloader = DataLoader(train_dataset, batch_size=batch_size, shuffle=shuffle)
+        val_dataloader = DataLoader(val_dataset, batch_size=batch_size, shuffle=shuffle)
+        test_dataloader = DataLoader(test_dataset, batch_size=batch_size, shuffle=shuffle)
+
+
+        return train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, means, stds

--- a/torch_geometric_temporal/dataset/pems.py
+++ b/torch_geometric_temporal/dataset/pems.py
@@ -12,20 +12,18 @@ import pandas as pd
 import pickle
 
 class PemsDatasetLoader(object):
-    """A traffic forecasting dataset as described in Diffusion Convolution Layer Paper.
+    """
+    A traffic forecasting dataset for the entirety of California. This traffic dataset is collected by California 
+    Transportation Agencies (CalTrans) Performance Measurement System (PeMS). 
 
-    This traffic dataset is collected by California Transportation Agencies (CalTrans)
-    Performance Measurement System (PeMS). It is represented by a network of 325 traffic sensors
-    in the Bay Area with 6 months of traffic readings ranging from Jan 1st 2017 to May 31th 2017
-    in 5 minute intervals.
-
-    For details see: `"Diffusion Convolutional Recurrent Neural Network:
-    Data-Driven Traffic Forecasting" <https://arxiv.org/abs/1707.01926>`_
+    For details see: `"Graph-partitioning-based diffusion convolutional 
+    recurrent neural network for large-scale traffic forecasting" 
+    <https://arxiv.org/abs/1909.11197>`_
     """
 
     def __init__(self, raw_data_dir=os.path.join(os.getcwd(), "data"),index=False):
         if not index:
-            NotImplementedError("The PeMS dataset does not support batching with the index-method")
+            NotImplementedError("The PeMS dataset does not support batching without  the index-method")
 
 
         super(PemsDatasetLoader, self).__init__()
@@ -41,7 +39,6 @@ class PemsDatasetLoader(object):
 
     def _read_web_data(self):  
         PeMS_file_links = {
-            "pems_cali_distances.csv": "https://anl.app.box.com/shared/static/cfnc6wryh4yrp58qfc5z7tyxbbpj4gek",
             "pems_cali_adj_mat.pkl" : "https://anl.app.box.com/shared/static/4143x1repqa1u26aiz7o2rvw3vpcu0wp",
             "pems_cali_speed.h5": "https://anl.app.box.com/shared/static/7hfhtie02iufy75ac1d8g8530majwci0"
         }          

--- a/torch_geometric_temporal/dataset/pems.py
+++ b/torch_geometric_temporal/dataset/pems.py
@@ -65,7 +65,7 @@ class PemsDatasetLoader(object):
                         progress_bar.update(len(chunk))
          
     
-    def get_index_dataset(self, lags=12, batch_size=64, shuffle=False, allGPU=-1, ratio=(0.7, 0.1, 0.2)):
+    def get_index_dataset(self, lags=12, batch_size=64, shuffle=False, allGPU=-1, ratio=(0.7, 0.1, 0.2), dask_batching=False):
         """
         Returns torch dataloaders using index batching for Chickenpox Hungary dataset.
 

--- a/torch_geometric_temporal/dataset/pems.py
+++ b/torch_geometric_temporal/dataset/pems.py
@@ -67,7 +67,7 @@ class PemsDatasetLoader(object):
     
     def get_index_dataset(self, lags=12, batch_size=64, shuffle=False, allGPU=-1, ratio=(0.7, 0.1, 0.2), dask_batching=False):
         """
-        Returns torch dataloaders using index batching for Chickenpox Hungary dataset.
+        Returns torch dataloaders using index batching for PeMS dataset.
 
         Args:
             lags (int, optional): The number of time lags. Defaults to 12.

--- a/torch_geometric_temporal/dataset/pems.py
+++ b/torch_geometric_temporal/dataset/pems.py
@@ -5,7 +5,7 @@ from tqdm import tqdm
 import numpy as np
 import torch
 from torch_geometric.utils import dense_to_sparse
-from ..signal import StaticGraphTemporalSignal,IndexDataset
+from ..signal import StaticGraphTemporalSignal
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data import DataLoader
 import pandas as pd
@@ -25,6 +25,9 @@ class PemsDatasetLoader(object):
         if not index:
             NotImplementedError("The PeMS dataset does not support batching without  the index-method")
 
+        else:
+            from ..signal.index_dataset import IndexDataset
+            self.IndexDataset = IndexDataset 
 
         super(PemsDatasetLoader, self).__init__()
         self.index = index
@@ -150,9 +153,9 @@ class PemsDatasetLoader(object):
         x_val = x_i[num_train: num_train + num_val]
         x_test = x_i[-num_test:]
 
-        train_dataset = IndexDataset(x_train,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
-        val_dataset = IndexDataset(x_val,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
-        test_dataset = IndexDataset(x_test,data,lags,gpu=not (allGPU == -1),lazy=dask_batching)
+        train_dataset = self.IndexDataset(x_train,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
+        val_dataset = self.IndexDataset(x_val,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
+        test_dataset = self.IndexDataset(x_test,data,lags,gpu=not (allGPU == -1),lazy=dask_batching)
 
         if ddp_rank != -1:
             train_sampler = DistributedSampler(train_dataset,  num_replicas=world_size, rank=ddp_rank, shuffle=shuffle)

--- a/torch_geometric_temporal/dataset/pems.py
+++ b/torch_geometric_temporal/dataset/pems.py
@@ -27,7 +27,10 @@ class PemsDatasetLoader(object):
 
         else:
             from ..signal.index_dataset import IndexDataset
-            self.IndexDataset = IndexDataset 
+            import pandas as pd
+
+            self.IndexDataset = IndexDataset
+            self.pd = pd 
 
         super(PemsDatasetLoader, self).__init__()
         self.index = index
@@ -100,7 +103,7 @@ class PemsDatasetLoader(object):
         edges, edge_weights = dense_to_sparse(torch.from_numpy(adj_mx))
     
         # setup data
-        df = pd.read_hdf(os.path.join(self.raw_data_dir, "pems_cali_speed.h5"), "df")
+        df = self.pd.read_hdf(os.path.join(self.raw_data_dir, "pems_cali_speed.h5"), "df")
         num_samples, num_nodes = df.shape
         
 

--- a/torch_geometric_temporal/dataset/pems.py
+++ b/torch_geometric_temporal/dataset/pems.py
@@ -65,7 +65,7 @@ class PemsDatasetLoader(object):
                         progress_bar.update(len(chunk))
          
     
-    def get_index_dataset(self, lags=12, batch_size=64, shuffle=False, allGPU=-1, dask_batching=False, ratio=(0.7, 0.1, 0.2)):
+    def get_index_dataset(self, lags=12, batch_size=64, shuffle=False, allGPU=-1, ratio=(0.7, 0.1, 0.2)):
         """
         Returns torch dataloaders using index batching for Chickenpox Hungary dataset.
 
@@ -76,7 +76,6 @@ class PemsDatasetLoader(object):
             allGPU (int, optional): GPU device ID for performing preprocessing in GPU memory. 
                                     If -1, computation is done on CPU. Defaults to -1.
             ratio (tuple of float, optional): The desired train, validation, and test split ratios, respectively.
-            dask_batching (bool): Should dask batching be used
 
         Returns:
             Tuple[

--- a/torch_geometric_temporal/dataset/pems.py
+++ b/torch_geometric_temporal/dataset/pems.py
@@ -19,6 +19,12 @@ class PemsDatasetLoader(object):
     For details see: `"Graph-partitioning-based diffusion convolutional 
     recurrent neural network for large-scale traffic forecasting" 
     <https://arxiv.org/abs/1909.11197>`_
+
+    Args:
+        raw_data_dir (string, optional): The directory to download the PeMS files to. 
+            Defaults to "data/".
+        index (bool, optional): If True, initializes the dataloader to use index-based batching.
+            Defaults to False.
     """
 
     def __init__(self, raw_data_dir=os.path.join(os.getcwd(), "data"),index=False):
@@ -81,15 +87,16 @@ class PemsDatasetLoader(object):
             
 
         Returns:
-            Tuple[
-                DataLoader,  # Dataloader for the training set
-                DataLoader,  # Dataloader for the validation set
-                DataLoader,  # Dataloader for the test set
-                torch.tensor,  # Edge indices (shape: [2, num_edges])
-                torch.tensor,   # Edge weights (shape: [num_edges])
-                torch.tensor,   # Means
-                torch.tensor,   # Stds
-            ]
+        Tuple[torch.utils.data.DataLoader, torch.utils.data.DataLoader, torch.utils.data.DataLoader, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]: 
+        
+        A 7-tuple containing:
+            - **train_dataLoader** (*torch.utils.data.DataLoader*): Dataloader for the training set.
+            - **val_dataLoader** (*torch.utils.data.DataLoader*): Dataloader for the validation set.
+            - **test_dataLoader** (*torch.utils.data.DataLoader*): Dataloader for the test set.
+            - **edges** (*torch.Tensor*): The graph edges as a 2D matrix, shape `[2, num_edges]`.
+            - **edge_weights** (*torch.Tensor*): Each graph edge's weight, shape `[num_edges]`.
+            - **means** (*torch.Tensor*): The means of each feature dimension.
+            - **stds** (*torch.Tensor*): The standard deviations of each feature dimension.
         """
 
         # adj matrix setup

--- a/torch_geometric_temporal/dataset/pemsAllLA.py
+++ b/torch_geometric_temporal/dataset/pemsAllLA.py
@@ -9,6 +9,7 @@ from ..signal import StaticGraphTemporalSignal
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data import DataLoader
 import pickle
+from typing import Tuple
 
 class PemsAllLADatasetLoader(object):
     """
@@ -36,12 +37,6 @@ class PemsAllLADatasetLoader(object):
         self.raw_data_dir = raw_data_dir
         self._read_web_data()
 
-    def _download_url(self, url, save_path):  # pragma: no cover
-        context = ssl._create_unverified_context()
-        with urllib.request.urlopen(url, context=context) as dl_file:
-            with open(save_path, "wb") as out_file:
-                out_file.write(dl_file.read())
-
     def _read_web_data(self):  
         PeMS_file_links = {
                 "pems_AllLA_adj_mat.pkl": "https://anl.app.box.com/shared/static/9qc2lc1147xzh8kmq3j4fuo4buiksxua",
@@ -68,8 +63,9 @@ class PemsAllLADatasetLoader(object):
                         progress_bar.update(len(chunk))
          
     
-    def get_index_dataset(self, lags=12, batch_size=64, shuffle=False, allGPU=-1, ratio=(0.7, 0.1, 0.2), 
-                          world_size=-1, ddp_rank=-1, dask_batching=False):
+    def get_index_dataset(self, lags: int = 12, batch_size: int = 64, shuffle: bool = False, allGPU: int = -1, 
+                          ratio: Tuple[float, float, float] = (0.7, 0.1, 0.2), world_size: int =-1, ddp_rank: int = -1, 
+                          dask_batching: bool = False) -> Tuple[DataLoader, DataLoader, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Returns torch dataloaders using index batching for PeMS dataset.
 

--- a/torch_geometric_temporal/dataset/pemsAllLA.py
+++ b/torch_geometric_temporal/dataset/pemsAllLA.py
@@ -8,7 +8,6 @@ from torch_geometric.utils import dense_to_sparse
 from ..signal import StaticGraphTemporalSignal
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data import DataLoader
-import pandas as pd
 import pickle
 
 class PemsAllLADatasetLoader(object):
@@ -27,6 +26,9 @@ class PemsAllLADatasetLoader(object):
             NotImplementedError("The PeMSAllLA dataset does not support batching without the index-method")
         else:
             from ..signal.index_dataset import IndexDataset
+            import pandas as pd
+
+            self.pd = pd
             self.IndexDataset = IndexDataset
 
         super(PemsAllLADatasetLoader, self).__init__()
@@ -100,7 +102,7 @@ class PemsAllLADatasetLoader(object):
         edges, edge_weights = dense_to_sparse(torch.from_numpy(adj_mx))
     
         # setup data
-        df = pd.read_hdf(os.path.join(self.raw_data_dir, "pems_AllLA_speed.h5"), "df")
+        df = self.pd.read_hdf(os.path.join(self.raw_data_dir, "pems_AllLA_speed.h5"), "df")
         num_samples, num_nodes = df.shape
         
 

--- a/torch_geometric_temporal/dataset/pemsAllLA.py
+++ b/torch_geometric_temporal/dataset/pemsAllLA.py
@@ -5,7 +5,7 @@ from tqdm import tqdm
 import numpy as np
 import torch
 from torch_geometric.utils import dense_to_sparse
-from ..signal import StaticGraphTemporalSignal,IndexDataset
+from ..signal import StaticGraphTemporalSignal
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data import DataLoader
 import pandas as pd
@@ -25,7 +25,9 @@ class PemsAllLADatasetLoader(object):
         
         if not index:
             NotImplementedError("The PeMSAllLA dataset does not support batching without the index-method")
-
+        else:
+            from ..signal.index_dataset import IndexDataset
+            self.IndexDataset = IndexDataset
 
         super(PemsAllLADatasetLoader, self).__init__()
         self.index = index
@@ -151,9 +153,9 @@ class PemsAllLADatasetLoader(object):
         x_val = x_i[num_train: num_train + num_val]
         x_test = x_i[-num_test:]
 
-        train_dataset = IndexDataset(x_train,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
-        val_dataset = IndexDataset(x_val,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
-        test_dataset = IndexDataset(x_test,data,lags,gpu=not (allGPU == -1),lazy=dask_batching)
+        train_dataset = self.IndexDataset(x_train,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
+        val_dataset = self.IndexDataset(x_val,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
+        test_dataset = self.IndexDataset(x_test,data,lags,gpu=not (allGPU == -1),lazy=dask_batching)
 
         if ddp_rank != -1:
             train_sampler = DistributedSampler(train_dataset,  num_replicas=world_size, rank=ddp_rank, shuffle=shuffle)

--- a/torch_geometric_temporal/dataset/pemsAllLA.py
+++ b/torch_geometric_temporal/dataset/pemsAllLA.py
@@ -1,0 +1,173 @@
+import os
+import ssl
+import requests
+from tqdm import tqdm
+import numpy as np
+import torch
+from torch_geometric.utils import dense_to_sparse
+from ..signal import StaticGraphTemporalSignal,IndexDataset
+from torch.utils.data.distributed import DistributedSampler
+from torch.utils.data import DataLoader
+import pandas as pd
+import pickle
+
+class PemsAllLADatasetLoader(object):
+    """
+    A traffic forecasting dataset that covers Los Angeles. This traffic dataset is collected by California 
+    Transportation Agencies (CalTrans) Performance Measurement System (PeMS). 
+
+    For details see: `"Graph-partitioning-based diffusion convolutional 
+    recurrent neural network for large-scale traffic forecasting" 
+    <https://arxiv.org/abs/1909.11197>`_
+    """
+
+    def __init__(self, raw_data_dir=os.path.join(os.getcwd(), "data"),index=False):
+        
+        if not index:
+            NotImplementedError("The PeMSAllLA dataset does not support batching without the index-method")
+
+
+        super(PemsAllLADatasetLoader, self).__init__()
+        self.index = index
+        self.raw_data_dir = raw_data_dir
+        self._read_web_data()
+
+    def _download_url(self, url, save_path):  # pragma: no cover
+        context = ssl._create_unverified_context()
+        with urllib.request.urlopen(url, context=context) as dl_file:
+            with open(save_path, "wb") as out_file:
+                out_file.write(dl_file.read())
+
+    def _read_web_data(self):  
+        PeMS_file_links = {
+                "pems_AllLA_adj_mat.pkl": "https://anl.app.box.com/shared/static/9qc2lc1147xzh8kmq3j4fuo4buiksxua",
+                "pems_AllLA_speed.h5": "https://anl.app.box.com/shared/static/crzf75ein8s839de8fklpubauddv1p6w"
+        }          
+        
+
+        for key in PeMS_file_links.keys():
+            
+            # Check if file is in data folder from working directory, otherwise download
+            if not os.path.isfile(
+            os.path.join(self.raw_data_dir,key)
+            ):
+                print("Downloading ", key, flush=True)
+                
+                response = requests.get(PeMS_file_links[key], stream=True)
+                file_size = int(response.headers.get('content-length', 0))
+
+                with open(os.path.join(self.raw_data_dir, key), "wb") as file, tqdm(
+                    total=file_size, unit="B", unit_scale=True, unit_divisor=1024
+                ) as progress_bar:
+                    for chunk in response.iter_content(chunk_size=33554432):
+                        file.write(chunk)
+                        progress_bar.update(len(chunk))
+         
+    
+    def get_index_dataset(self, lags=12, batch_size=64, shuffle=False, allGPU=-1, ratio=(0.7, 0.1, 0.2), 
+                          world_size=-1, ddp_rank=-1, dask_batching=False):
+        """
+        Returns torch dataloaders using index batching for PeMS dataset.
+
+        Args:
+            lags (int, optional): The number of time lags. Defaults to 12.
+            batch_size (int, optional): Batch size. Defaults to 64.
+            shuffle (bool, optional): If the data should be shuffled. Defaults to False.
+            allGPU (int, optional): GPU device ID for performing preprocessing in GPU memory. 
+                                    If -1, computation is done on CPU. Defaults to -1.
+            world_size (int, optional): The number of workers if DDP is being used. Defaults to -1.
+            ddp_rank (int, optional): The DDP rank of the worker if DDP is being used. Defaults to -1.
+            ratio (tuple of float, optional): The desired train, validation, and test split ratios, respectively.
+            
+
+        Returns:
+            Tuple[
+                DataLoader,  # Dataloader for the training set
+                DataLoader,  # Dataloader for the validation set
+                DataLoader,  # Dataloader for the test set
+                torch.tensor,  # Edge indices (shape: [2, num_edges])
+                torch.tensor,   # Edge weights (shape: [num_edges])
+                torch.tensor,   # Means
+                torch.tensor,   # Stds
+            ]
+        """
+
+        # adj matrix setup
+        with open(os.path.join(self.raw_data_dir, "pems_AllLA_adj_mat.pkl"), 'rb') as f:
+            _, _, adj_mx = pickle.load(f)
+        edges, edge_weights = dense_to_sparse(torch.from_numpy(adj_mx))
+    
+        # setup data
+        df = pd.read_hdf(os.path.join(self.raw_data_dir, "pems_AllLA_speed.h5"), "df")
+        num_samples, num_nodes = df.shape
+        
+
+        
+        if allGPU != -1:
+            data = torch.empty((num_samples, num_nodes, 2), device='cuda',dtype=torch.float)
+            data[...,0] = torch.tensor(df.values).to(f"cuda:{allGPU}")
+            
+        else:
+            data = np.expand_dims(df.values, axis=-1)
+            data_list = [data[:]]
+
+
+        
+        if allGPU != -1:
+            time_ind = (df.index.values - df.index.values.astype("datetime64[D]")) / np.timedelta64(1, "D")
+            data[...,1] = torch.squeeze(torch.tensor(np.tile(time_ind, [1, num_nodes, 1]).transpose((2, 1, 0)))).to(f"cuda:{allGPU}")
+        else:
+            time_ind = (df.index.values - df.index.values.astype("datetime64[D]")) / np.timedelta64(1, "D")
+            time_in_day = np.tile(time_ind, [1, num_nodes, 1]).transpose((2, 1, 0))
+            data_list.append(time_in_day)
+        
+
+        # Normalise as in DCRNN paper (via Z-Score Method)
+        if allGPU != -1:
+            data = data.to(f"cuda:{allGPU}")
+            
+            means = torch.mean(data, dim=(0, 1), keepdim=True) 
+            stds = torch.std(data, dim=(0, 1), keepdim=True) 
+            data = (data - means) / stds
+            
+        else:
+            data = np.concatenate(data_list, axis=-1)
+            means = np.mean(data, axis=(0, 1))
+            stds = np.std(data, axis=(0, 1))
+            data = (data - means) / stds 
+            
+            means = torch.tensor(means,dtype=torch.float)
+            stds = torch.tensor(stds,dtype=torch.float)
+            
+        
+        num_samples = data.shape[0]
+        x_i = np.arange(num_samples - (2 * lags - 1))
+        num_samples = x_i.shape[0]
+        num_train = round(num_samples * ratio[0])
+        num_test = round(num_samples * ratio[2])
+        num_val = num_samples - num_train - num_test
+
+        x_train = x_i[:num_train]
+        x_val = x_i[num_train: num_train + num_val]
+        x_test = x_i[-num_test:]
+
+        train_dataset = IndexDataset(x_train,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
+        val_dataset = IndexDataset(x_val,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
+        test_dataset = IndexDataset(x_test,data,lags,gpu=not (allGPU == -1),lazy=dask_batching)
+
+        if ddp_rank != -1:
+            train_sampler = DistributedSampler(train_dataset,  num_replicas=world_size, rank=ddp_rank, shuffle=shuffle)
+            train_dataloader = DataLoader(train_dataset, batch_size=batch_size, sampler=train_sampler)
+            
+            val_sampler = DistributedSampler(val_dataset, num_replicas=world_size, rank=ddp_rank, shuffle=shuffle)                  
+            val_dataloader = DataLoader(val_dataset, batch_size=batch_size, sampler=val_sampler)
+            
+            test_sampler = DistributedSampler(test_dataset, num_replicas=world_size, rank=ddp_rank, shuffle=shuffle)                  
+            test_dataloader = DataLoader(test_dataset, batch_size=batch_size, sampler=test_sampler)
+        else:
+            train_dataloader = DataLoader(train_dataset, batch_size=batch_size, shuffle=shuffle)
+            val_dataloader = DataLoader(val_dataset, batch_size=batch_size, shuffle=shuffle)
+            test_dataloader = DataLoader(test_dataset, batch_size=batch_size, shuffle=shuffle)
+
+
+        return train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, means, stds

--- a/torch_geometric_temporal/dataset/pemsAllLA.py
+++ b/torch_geometric_temporal/dataset/pemsAllLA.py
@@ -19,6 +19,12 @@ class PemsAllLADatasetLoader(object):
     For details see: `"Graph-partitioning-based diffusion convolutional 
     recurrent neural network for large-scale traffic forecasting" 
     <https://arxiv.org/abs/1909.11197>`_
+
+    Args:
+        raw_data_dir (string, optional): The directory to download the PeMS-All-LA files to. 
+            Defaults to "data/".
+        index (bool, optional): If True, initializes the dataloader to use index-based batching.
+            Defaults to False.
     """
 
     def __init__(self, raw_data_dir=os.path.join(os.getcwd(), "data"),index=False):
@@ -78,18 +84,18 @@ class PemsAllLADatasetLoader(object):
             world_size (int, optional): The number of workers if DDP is being used. Defaults to -1.
             ddp_rank (int, optional): The DDP rank of the worker if DDP is being used. Defaults to -1.
             ratio (tuple of float, optional): The desired train, validation, and test split ratios, respectively.
-            
-
+                    
         Returns:
-            Tuple[
-                DataLoader,  # Dataloader for the training set
-                DataLoader,  # Dataloader for the validation set
-                DataLoader,  # Dataloader for the test set
-                torch.tensor,  # Edge indices (shape: [2, num_edges])
-                torch.tensor,   # Edge weights (shape: [num_edges])
-                torch.tensor,   # Means
-                torch.tensor,   # Stds
-            ]
+        Tuple[torch.utils.data.DataLoader, torch.utils.data.DataLoader, torch.utils.data.DataLoader, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]: 
+        
+        A 7-tuple containing:
+            - **train_dataLoader** (*torch.utils.data.DataLoader*): Dataloader for the training set.
+            - **val_dataLoader** (*torch.utils.data.DataLoader*): Dataloader for the validation set.
+            - **test_dataLoader** (*torch.utils.data.DataLoader*): Dataloader for the test set.
+            - **edges** (*torch.Tensor*): The graph edges as a 2D matrix, shape `[2, num_edges]`.
+            - **edge_weights** (*torch.Tensor*): Each graph edge's weight, shape `[num_edges]`.
+            - **means** (*torch.Tensor*): The means of each feature dimension.
+            - **stds** (*torch.Tensor*): The standard deviations of each feature dimension.
         """
 
         # adj matrix setup

--- a/torch_geometric_temporal/dataset/pems_bay.py
+++ b/torch_geometric_temporal/dataset/pems_bay.py
@@ -29,6 +29,7 @@ class PemsBayDatasetLoader(object):
         
         if index:
             from ..signal import IndexDataset
+            self.IndexDataset = IndexDataset 
 
     def _download_url(self, url, save_path):  # pragma: no cover
         context = ssl._create_unverified_context()
@@ -148,6 +149,9 @@ class PemsBayDatasetLoader(object):
             ]
         """
 
+        if not self.index:
+            raise ValueError("get_index_dataset requires 'index=True' in the constructor.")
+            
         # adj matrix setup
         A = np.load(os.path.join(self.raw_data_dir, "pems_adj_mat.npy"))
         edges, edge_weights = dense_to_sparse(torch.from_numpy(A))
@@ -191,9 +195,9 @@ class PemsBayDatasetLoader(object):
         x_test = x_i[-num_test:]
 
 
-        train_dataset = IndexDataset(x_train,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
-        val_dataset = IndexDataset(x_val,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
-        test_dataset = IndexDataset(x_test,data,lags,gpu=not (allGPU == -1),lazy=dask_batching)
+        train_dataset = self.IndexDataset(x_train,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
+        val_dataset = self.IndexDataset(x_val,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
+        test_dataset = self.IndexDataset(x_test,data,lags,gpu=not (allGPU == -1),lazy=dask_batching)
         
         if ddp_rank != -1:
             train_sampler = DistributedSampler(train_dataset,  num_replicas=world_size, rank=ddp_rank, shuffle=shuffle)

--- a/torch_geometric_temporal/dataset/pems_bay.py
+++ b/torch_geometric_temporal/dataset/pems_bay.py
@@ -119,7 +119,7 @@ class PemsBayDatasetLoader(object):
         return dataset
     def get_index_dataset(self, lags=12, batch_size=64, shuffle=False, allGPU=-1, ratio=(0.7, 0.1, 0.2),dask_batching=False):
         """
-        Returns torch dataloaders using index batching for Chickenpox Hungary dataset.
+        Returns torch dataloaders using index batching for PeMSBay dataset.
 
         Args:
             lags (int, optional): The number of time lags. Defaults to 12.

--- a/torch_geometric_temporal/dataset/pems_bay.py
+++ b/torch_geometric_temporal/dataset/pems_bay.py
@@ -117,7 +117,7 @@ class PemsBayDatasetLoader(object):
             self.edges, self.edge_weights, self.features, self.targets
         )
         return dataset
-    def get_index_dataset(self, lags=12, batch_size=64, shuffle=False, allGPU=-1, ratio=(0.7, 0.1, 0.2)):
+    def get_index_dataset(self, lags=12, batch_size=64, shuffle=False, allGPU=-1, ratio=(0.7, 0.1, 0.2),dask_batching=False):
         """
         Returns torch dataloaders using index batching for Chickenpox Hungary dataset.
 

--- a/torch_geometric_temporal/dataset/pems_bay.py
+++ b/torch_geometric_temporal/dataset/pems_bay.py
@@ -20,9 +20,15 @@ class PemsBayDatasetLoader(object):
 
     For details see: `"Diffusion Convolutional Recurrent Neural Network:
     Data-Driven Traffic Forecasting" <https://arxiv.org/abs/1707.01926>`_
+
+    Args:
+        raw_data_dir (string, optional): The directory to download the PeMS-Bay files to. 
+            Defaults to "data/".
+        index (bool, optional): If True, initializes the dataloader to use index-based batching.
+            Defaults to False.
     """
 
-    def __init__(self, raw_data_dir=os.path.join(os.getcwd(), "data"),index=False):
+    def __init__(self, raw_data_dir: str =os.path.join(os.getcwd(), "data"),index: bool = False):
         super(PemsBayDatasetLoader, self).__init__()
         self.index = index
         self.raw_data_dir = raw_data_dir
@@ -141,17 +147,21 @@ class PemsBayDatasetLoader(object):
             ddp_rank (int, optional): The DDP rank of the worker if DDP is being used. Defaults to -1.
             ratio (tuple of float, optional): The desired train, validation, and test split ratios, respectively.
 
+        
         Returns:
-            Tuple[
-                DataLoader,  # Dataloader for the training set
-                DataLoader,  # Dataloader for the validation set
-                DataLoader,  # Dataloader for the test set
-                torch.tensor,  # Edge indices (shape: [2, num_edges])
-                torch.tensor,   # Edge weights (shape: [num_edges])
-                torch.tensor,   # Means
-                torch.tensor,   # Stds
-            ]
+            Tuple[torch.utils.data.DataLoader, torch.utils.data.DataLoader, torch.utils.data.DataLoader, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]: 
+            
+            A 7-tuple containing:
+                - **train_dataLoader** (*torch.utils.data.DataLoader*): Dataloader for the training set.
+                - **val_dataLoader** (*torch.utils.data.DataLoader*): Dataloader for the validation set.
+                - **test_dataLoader** (*torch.utils.data.DataLoader*): Dataloader for the test set.
+                - **edges** (*torch.Tensor*): The graph edges as a 2D matrix, shape `[2, num_edges]`.
+                - **edge_weights** (*torch.Tensor*): Each graph edge's weight, shape `[num_edges]`.
+                - **means** (*torch.Tensor*): The means of each feature dimension.
+                - **stds** (*torch.Tensor*): The standard deviations of each feature dimension.
         """
+
+
 
         if not self.index:
             raise ValueError("get_index_dataset requires 'index=True' in the constructor.")

--- a/torch_geometric_temporal/dataset/pems_bay.py
+++ b/torch_geometric_temporal/dataset/pems_bay.py
@@ -5,7 +5,7 @@ import zipfile
 import numpy as np
 import torch
 from torch_geometric.utils import dense_to_sparse
-from ..signal import StaticGraphTemporalSignal,IndexDataset
+from ..signal import StaticGraphTemporalSignal
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data import DataLoader
 
@@ -26,6 +26,9 @@ class PemsBayDatasetLoader(object):
         self.index = index
         self.raw_data_dir = raw_data_dir
         self._read_web_data()
+        
+        if index:
+            from ..signal import IndexDataset
 
     def _download_url(self, url, save_path):  # pragma: no cover
         context = ssl._create_unverified_context()

--- a/torch_geometric_temporal/dataset/pems_bay.py
+++ b/torch_geometric_temporal/dataset/pems_bay.py
@@ -8,6 +8,7 @@ from torch_geometric.utils import dense_to_sparse
 from ..signal import StaticGraphTemporalSignal
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data import DataLoader
+from typing import Tuple
 
 class PemsBayDatasetLoader(object):
     """A traffic forecasting dataset as described in Diffusion Convolution Layer Paper.
@@ -122,8 +123,11 @@ class PemsBayDatasetLoader(object):
             self.edges, self.edge_weights, self.features, self.targets
         )
         return dataset
-    def get_index_dataset(self, lags=12, batch_size=64, shuffle=False, allGPU=-1, ratio=(0.7, 0.1, 0.2), 
-                          world_size=-1, ddp_rank=-1, dask_batching=False):
+    
+    def get_index_dataset(self, lags: int = 12, batch_size: int = 64, shuffle: bool = False, allGPU: int = -1, 
+                          ratio: Tuple[float, float, float] = (0.7, 0.1, 0.2), world_size: int =-1, ddp_rank: int = -1, 
+                          dask_batching: bool = False) -> Tuple[DataLoader, DataLoader, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    
         """
         Returns torch dataloaders using index batching for PeMSBay dataset.
 

--- a/torch_geometric_temporal/dataset/pems_bay.py
+++ b/torch_geometric_temporal/dataset/pems_bay.py
@@ -135,18 +135,16 @@ class PemsBayDatasetLoader(object):
                 DataLoader,  # Dataloader for the training set
                 DataLoader,  # Dataloader for the validation set
                 DataLoader,  # Dataloader for the test set
-                np.ndarray,  # Edge indices (shape: [2, num_edges])
-                np.ndarray,   # Edge weights (shape: [num_edges])
-                np.ndarray,   # Means
-                np.ndarray,   # Stds
+                torch.tensor,  # Edge indices (shape: [2, num_edges])
+                torch.tensor,   # Edge weights (shape: [num_edges])
+                torch.tensor,   # Means
+                torch.tensor,   # Stds
             ]
         """
 
         # adj matrix setup
         A = np.load(os.path.join(self.raw_data_dir, "pems_adj_mat.npy"))
-        edge_indices, values = dense_to_sparse(torch.from_numpy(A))
-        edges = edge_indices.numpy()
-        edge_weights = values.numpy()
+        edges, edge_weights = dense_to_sparse(torch.from_numpy(A))
 
         # setup data
         data = np.load(os.path.join(self.raw_data_dir, "pems_node_values.npy")).transpose((1, 2, 0))
@@ -170,6 +168,9 @@ class PemsBayDatasetLoader(object):
             stds = np.std(data, axis=(0, 2))
             data = data / stds.reshape(1, -1, 1)
             data = data.transpose((2, 0, 1))
+
+            means = torch.tensor(means,dtype=torch.float)
+            stds = torch.tensor(stds,dtype=torch.float)
         
         
         num_samples = data.shape[0]

--- a/torch_geometric_temporal/dataset/pems_bay.py
+++ b/torch_geometric_temporal/dataset/pems_bay.py
@@ -117,7 +117,7 @@ class PemsBayDatasetLoader(object):
             self.edges, self.edge_weights, self.features, self.targets
         )
         return dataset
-    def get_index_dataset(self, lags=12, batch_size=64, shuffle=False, allGPU=-1, dask_batching=False, ratio=(0.7, 0.1, 0.2)):
+    def get_index_dataset(self, lags=12, batch_size=64, shuffle=False, allGPU=-1, ratio=(0.7, 0.1, 0.2)):
         """
         Returns torch dataloaders using index batching for Chickenpox Hungary dataset.
 
@@ -128,7 +128,6 @@ class PemsBayDatasetLoader(object):
             allGPU (int, optional): GPU device ID for performing preprocessing in GPU memory. 
                                     If -1, computation is done on CPU. Defaults to -1.
             ratio (tuple of float, optional): The desired train, validation, and test split ratios, respectively.
-            dask_batching (bool): Should dask batching be used
 
         Returns:
             Tuple[

--- a/torch_geometric_temporal/dataset/pems_bay.py
+++ b/torch_geometric_temporal/dataset/pems_bay.py
@@ -28,7 +28,7 @@ class PemsBayDatasetLoader(object):
         self._read_web_data()
         
         if index:
-            from ..signal import IndexDataset
+            from ..signal.index_dataset import IndexDataset
             self.IndexDataset = IndexDataset 
 
     def _download_url(self, url, save_path):  # pragma: no cover

--- a/torch_geometric_temporal/dataset/pems_bay.py
+++ b/torch_geometric_temporal/dataset/pems_bay.py
@@ -6,6 +6,7 @@ import numpy as np
 import torch
 from torch_geometric.utils import dense_to_sparse
 from ..signal import StaticGraphTemporalSignal,IndexDataset
+from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data import DataLoader
 
 class PemsBayDatasetLoader(object):
@@ -117,7 +118,8 @@ class PemsBayDatasetLoader(object):
             self.edges, self.edge_weights, self.features, self.targets
         )
         return dataset
-    def get_index_dataset(self, lags=12, batch_size=64, shuffle=False, allGPU=-1, ratio=(0.7, 0.1, 0.2),dask_batching=False):
+    def get_index_dataset(self, lags=12, batch_size=64, shuffle=False, allGPU=-1, ratio=(0.7, 0.1, 0.2), 
+                          world_size=-1, ddp_rank=-1, dask_batching=False):
         """
         Returns torch dataloaders using index batching for PeMSBay dataset.
 
@@ -127,6 +129,8 @@ class PemsBayDatasetLoader(object):
             shuffle (bool, optional): If the data should be shuffled. Defaults to False.
             allGPU (int, optional): GPU device ID for performing preprocessing in GPU memory. 
                                     If -1, computation is done on CPU. Defaults to -1.
+            world_size (int, optional): The number of workers if DDP is being used. Defaults to -1.
+            ddp_rank (int, optional): The DDP rank of the worker if DDP is being used. Defaults to -1.
             ratio (tuple of float, optional): The desired train, validation, and test split ratios, respectively.
 
         Returns:
@@ -188,9 +192,19 @@ class PemsBayDatasetLoader(object):
         val_dataset = IndexDataset(x_val,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
         test_dataset = IndexDataset(x_test,data,lags,gpu=not (allGPU == -1),lazy=dask_batching)
         
-        train_dataloader = DataLoader(train_dataset, batch_size=batch_size, shuffle=shuffle)
-        val_dataloader = DataLoader(val_dataset, batch_size=batch_size, shuffle=shuffle)
-        test_dataloader = DataLoader(test_dataset, batch_size=batch_size, shuffle=shuffle)
+        if ddp_rank != -1:
+            train_sampler = DistributedSampler(train_dataset,  num_replicas=world_size, rank=ddp_rank, shuffle=shuffle)
+            train_dataloader = DataLoader(train_dataset, batch_size=batch_size, sampler=train_sampler)
+            
+            val_sampler = DistributedSampler(val_dataset, num_replicas=world_size, rank=ddp_rank, shuffle=shuffle)                  
+            val_dataloader = DataLoader(val_dataset, batch_size=batch_size, sampler=val_sampler)
+            
+            test_sampler = DistributedSampler(test_dataset, num_replicas=world_size, rank=ddp_rank, shuffle=shuffle)                  
+            test_dataloader = DataLoader(test_dataset, batch_size=batch_size, sampler=test_sampler)
+        else:
+            train_dataloader = DataLoader(train_dataset, batch_size=batch_size, shuffle=shuffle)
+            val_dataloader = DataLoader(val_dataset, batch_size=batch_size, shuffle=shuffle)
+            test_dataloader = DataLoader(test_dataset, batch_size=batch_size, shuffle=shuffle)
 
 
         return train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, means, stds

--- a/torch_geometric_temporal/dataset/windmilllarge.py
+++ b/torch_geometric_temporal/dataset/windmilllarge.py
@@ -19,7 +19,7 @@ class WindmillOutputLargeDatasetLoader(object):
         self.index = index
 
         if index:
-            from ..signal import IndexDataset
+            from ..signal.index_dataset import IndexDataset
             self.IndexDataset = IndexDataset 
 
 

--- a/torch_geometric_temporal/dataset/windmilllarge.py
+++ b/torch_geometric_temporal/dataset/windmilllarge.py
@@ -2,7 +2,9 @@ import json
 import ssl
 import urllib.request
 import numpy as np
-from ..signal import StaticGraphTemporalSignal
+from ..signal import StaticGraphTemporalSignal,IndexDataset
+import torch
+from torch.utils.data import DataLoader
 
 
 class WindmillOutputLargeDatasetLoader(object):
@@ -12,7 +14,7 @@ class WindmillOutputLargeDatasetLoader(object):
     variable allows for regression tasks.
     """
 
-    def __init__(self):
+    def __init__(self, index=False):
         self._read_web_data()
 
     def _read_web_data(self):
@@ -58,3 +60,70 @@ class WindmillOutputLargeDatasetLoader(object):
             self._edges, self._edge_weights, self.features, self.targets
         )
         return dataset
+
+    def get_index_dataset(self, lags=8, batch_size=64, shuffle=False, allGPU=-1, ratio=(0.7, 0.1, 0.2),dask_batching=False):
+        """
+        Returns torch dataloaders using index batching for WindmillLarge dataset.
+
+        Args:
+            lags (int, optional): The number of time lags. Defaults to 8.
+            batch_size (int, optional): Batch size. Defaults to 64.
+            shuffle (bool, optional): If the data should be shuffled. Defaults to False.
+            allGPU (int, optional): GPU device ID for performing preprocessing in GPU memory. 
+                                    If -1, computation is done on CPU. Defaults to -1.
+            ratio (tuple of float, optional): The desired train, validation, and test split ratios, respectively.
+
+        Returns:
+            Tuple[
+                DataLoader,  # Dataloader for the training set
+                DataLoader,  # Dataloader for the validation set
+                DataLoader,  # Dataloader for the test set
+                torch.tensor,  # Edge indices (shape: [2, num_edges])
+                torch.tensor   # Edge weights (shape: [num_edges])
+                torch.tensor,   # Means
+                torch.tensor,   # Stds
+            ]
+        """
+
+        # adj matrix setup
+        edges = torch.tensor(self._dataset["edges"], dtype=torch.int64).T
+        edge_weights = torch.tensor(self._dataset["weights"], dtype=torch.float)
+        
+        # data preprocessing
+        data = np.stack(self._dataset["block"])
+        num_samples = data.shape[0]    
+        
+        if allGPU != -1:
+            data = torch.tensor(data, dtype=torch.float).to(f"cuda:{allGPU}")
+            mean = torch.mean(data, axis=0)
+            std = torch.std(data, axis=0) + 10 ** -10
+            data  = (data - mean) / std
+            data = data.unsqueeze(-1)
+        else:
+            mean = np.mean(data, axis=0)
+            std = np.std(data, axis=0) + 10 ** -10
+            data  = (data - mean) / std
+            data = np.expand_dims(data, axis=-1)
+            
+            mean = torch.tensor(mean,dtype=torch.float)
+            std = torch.tensor(std,dtype=torch.float) 
+
+        x_i = np.arange(num_samples - (2 * lags - 1))
+        num_samples = x_i.shape[0]
+        num_train = round(num_samples * ratio[0])
+        num_test = round(num_samples * ratio[2])
+        num_val = num_samples - num_train - num_test
+
+        x_train = x_i[:num_train]
+        x_val = x_i[num_train: num_train + num_val]
+        x_test = x_i[-num_test:]
+
+        train_dataset = IndexDataset(x_train,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
+        val_dataset = IndexDataset(x_val,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
+        test_dataset = IndexDataset(x_test,data,lags,gpu=not (allGPU == -1),lazy=dask_batching)
+        
+        train_dataloader = DataLoader(train_dataset, batch_size=batch_size, shuffle=shuffle)
+        val_dataloader = DataLoader(val_dataset, batch_size=batch_size, shuffle=shuffle)
+        test_dataloader = DataLoader(test_dataset, batch_size=batch_size, shuffle=shuffle)
+
+        return train_dataloader, val_dataloader, test_dataloader, edges, edge_weights, mean, std

--- a/torch_geometric_temporal/dataset/windmilllarge.py
+++ b/torch_geometric_temporal/dataset/windmilllarge.py
@@ -2,7 +2,7 @@ import json
 import ssl
 import urllib.request
 import numpy as np
-from ..signal import StaticGraphTemporalSignal,IndexDataset
+from ..signal import StaticGraphTemporalSignal
 import torch
 from torch.utils.data import DataLoader
 
@@ -16,6 +16,9 @@ class WindmillOutputLargeDatasetLoader(object):
 
     def __init__(self, index=False):
         self._read_web_data()
+
+        if index:
+            from ..signal import IndexDataset
 
     def _read_web_data(self):
         url = "https://graphmining.ai/temporal_datasets/windmill_output.json"

--- a/torch_geometric_temporal/dataset/windmilllarge.py
+++ b/torch_geometric_temporal/dataset/windmilllarge.py
@@ -12,6 +12,10 @@ class WindmillOutputLargeDatasetLoader(object):
     for more than 2 years. Vertices represent 319 windmills and
     weighted edges describe the strength of relationships. The target
     variable allows for regression tasks.
+
+    Args:
+        index (bool, optional): If True, initializes the dataloader to use index-based batching.
+            Defaults to False.
     """
 
     def __init__(self, index=False):
@@ -80,15 +84,16 @@ class WindmillOutputLargeDatasetLoader(object):
             ratio (tuple of float, optional): The desired train, validation, and test split ratios, respectively.
 
         Returns:
-            Tuple[
-                DataLoader,  # Dataloader for the training set
-                DataLoader,  # Dataloader for the validation set
-                DataLoader,  # Dataloader for the test set
-                torch.tensor,  # Edge indices (shape: [2, num_edges])
-                torch.tensor   # Edge weights (shape: [num_edges])
-                torch.tensor,   # Means
-                torch.tensor,   # Stds
-            ]
+            Tuple[torch.utils.data.DataLoader, torch.utils.data.DataLoader, torch.utils.data.DataLoader, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]: 
+            
+            A 7-tuple containing:
+                - **train_dataLoader** (*torch.utils.data.DataLoader*): Dataloader for the training set.
+                - **val_dataLoader** (*torch.utils.data.DataLoader*): Dataloader for the validation set.
+                - **test_dataLoader** (*torch.utils.data.DataLoader*): Dataloader for the test set.
+                - **edges** (*torch.Tensor*): The graph edges as a 2D matrix, shape `[2, num_edges]`.
+                - **edge_weights** (*torch.Tensor*): Each graph edge's weight, shape `[num_edges]`.
+                - **means** (*torch.Tensor*): The means of each feature dimension.
+                - **stds** (*torch.Tensor*): The standard deviations of each feature dimension.
         """
         if not self.index:
             raise ValueError("get_index_dataset requires 'index=True' in the constructor.")

--- a/torch_geometric_temporal/dataset/windmilllarge.py
+++ b/torch_geometric_temporal/dataset/windmilllarge.py
@@ -16,9 +16,12 @@ class WindmillOutputLargeDatasetLoader(object):
 
     def __init__(self, index=False):
         self._read_web_data()
+        self.index = index
 
         if index:
             from ..signal import IndexDataset
+            self.IndexDataset = IndexDataset 
+
 
     def _read_web_data(self):
         url = "https://graphmining.ai/temporal_datasets/windmill_output.json"
@@ -87,7 +90,8 @@ class WindmillOutputLargeDatasetLoader(object):
                 torch.tensor,   # Stds
             ]
         """
-
+        if not self.index:
+            raise ValueError("get_index_dataset requires 'index=True' in the constructor.")
         # adj matrix setup
         edges = torch.tensor(self._dataset["edges"], dtype=torch.int64).T
         edge_weights = torch.tensor(self._dataset["weights"], dtype=torch.float)
@@ -121,9 +125,9 @@ class WindmillOutputLargeDatasetLoader(object):
         x_val = x_i[num_train: num_train + num_val]
         x_test = x_i[-num_test:]
 
-        train_dataset = IndexDataset(x_train,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
-        val_dataset = IndexDataset(x_val,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
-        test_dataset = IndexDataset(x_test,data,lags,gpu=not (allGPU == -1),lazy=dask_batching)
+        train_dataset = self.IndexDataset(x_train,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
+        val_dataset = self.IndexDataset(x_val,data,lags,gpu=not (allGPU == -1), lazy=dask_batching)
+        test_dataset = self.IndexDataset(x_test,data,lags,gpu=not (allGPU == -1),lazy=dask_batching)
         
         train_dataloader = DataLoader(train_dataset, batch_size=batch_size, shuffle=shuffle)
         val_dataloader = DataLoader(val_dataset, batch_size=batch_size, shuffle=shuffle)

--- a/torch_geometric_temporal/nn/recurrent/__init__.py
+++ b/torch_geometric_temporal/nn/recurrent/__init__.py
@@ -5,7 +5,7 @@ from .gc_lstm import GCLSTM
 from .dygrae import DyGrEncoder
 from .evolvegcnh import EvolveGCNH
 from .evolvegcno import EvolveGCNO
-from .dcrnn import DCRNN
+from .dcrnn import DCRNN, BatchedDCRNN
 from .temporalgcn import TGCN
 from .temporalgcn import TGCN2
 from .attentiontemporalgcn import A3TGCN

--- a/torch_geometric_temporal/nn/recurrent/dcrnn.py
+++ b/torch_geometric_temporal/nn/recurrent/dcrnn.py
@@ -217,3 +217,215 @@ class DCRNN(torch.nn.Module):
         H_tilde = self._calculate_candidate_state(X, edge_index, edge_weight, H, R)
         H = self._calculate_hidden_state(Z, H, H_tilde)
         return H
+
+"""
+Extension to DCRNN that enables batching and seq-to-seq prediction
+"""
+class BatchedDConv(MessagePassing):
+    r"""An implementation of the Diffusion Convolution Layer.
+    For details see: `"Diffusion Convolutional Recurrent Neural Network:
+    Data-Driven Traffic Forecasting" <https://arxiv.org/abs/1707.01926>`_
+
+    Args:
+        in_channels (int): Number of input features.
+        out_channels (int): Number of output features.
+        K (int): Filter size :math:`K`.
+        bias (bool, optional): If set to :obj:`False`, the layer
+            will not learn an additive bias (default :obj:`True`).
+
+    """
+
+    def __init__(self, in_channels, out_channels, K, bias=True):
+        super(BatchedDConv, self).__init__(aggr="add", flow="source_to_target")
+        assert K > 0
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.weight = torch.nn.Parameter(torch.Tensor(2, K, in_channels, out_channels))
+
+        if bias:
+            self.bias = torch.nn.Parameter(torch.Tensor(out_channels))
+        else:
+            self.register_parameter("bias", None)
+
+        self.__reset_parameters()
+
+    def __reset_parameters(self):
+        # torch.nn.init.ones_(self.weight)
+        torch.nn.init.xavier_uniform_(self.weight)
+        torch.nn.init.zeros_(self.bias)
+
+    def message(self, x_j, norm):
+        return norm.view(-1, 1) * x_j
+
+    def forward(
+        self,
+        X: torch.FloatTensor,
+        edge_index: torch.LongTensor,
+        edge_weight: torch.FloatTensor,
+    ) -> torch.FloatTensor:
+        r"""Making a forward pass. If edge weights are not present the forward pass
+        defaults to an unweighted graph.
+
+        Arg types:
+            * **X** (PyTorch Float Tensor) - Node features.
+            * **edge_index** (PyTorch Long Tensor) - Graph edge indices.
+            * **edge_weight** (PyTorch Long Tensor, optional) - Edge weight vector.
+
+        Return types:
+            * **H** (PyTorch Float Tensor) - Hidden state matrix for all nodes.
+        """
+        adj_mat = to_dense_adj(edge_index, edge_attr=edge_weight)
+        adj_mat = adj_mat.reshape(adj_mat.size(1), adj_mat.size(2))
+        deg_out = torch.matmul(
+            adj_mat, torch.ones(size=(adj_mat.size(0), 1)).to(X.device)
+        )
+        deg_out = deg_out.flatten()
+        deg_in = torch.matmul(
+            torch.ones(size=(1, adj_mat.size(0))).to(X.device), adj_mat
+        )
+        deg_in = deg_in.flatten()
+
+        deg_out_inv = torch.reciprocal(deg_out)
+        deg_in_inv = torch.reciprocal(deg_in)
+        row, col = edge_index
+        norm_out = deg_out_inv[row]
+        norm_in = deg_in_inv[row]
+
+        reverse_edge_index = adj_mat.transpose(0, 1)
+        reverse_edge_index, vv = dense_to_sparse(reverse_edge_index)
+
+        Tx_0 = X
+        Tx_1 = X
+        H = torch.matmul(Tx_0, (self.weight[0])[0]) + torch.matmul(
+            Tx_0, (self.weight[1])[0]
+        )
+    
+        if self.weight.size(1) > 1:
+            Tx_1_o = self.propagate(edge_index, x=X, norm=norm_out, size=None)
+            Tx_1_i = self.propagate(reverse_edge_index, x=X, norm=norm_in, size=None)
+            H = (
+                H
+                + torch.matmul(Tx_1_o, (self.weight[0])[1])
+                + torch.matmul(Tx_1_i, (self.weight[1])[1])
+            )
+
+        for k in range(2, self.weight.size(1)):
+            Tx_2_o = self.propagate(edge_index, x=Tx_1_o, norm=norm_out, size=None)
+            Tx_2_o = 2.0 * Tx_2_o - Tx_0
+            Tx_2_i = self.propagate(
+                reverse_edge_index, x=Tx_1_i, norm=norm_in, size=None
+            )
+            Tx_2_i = 2.0 * Tx_2_i - Tx_0
+            H = (
+                H
+                + torch.matmul(Tx_2_o, (self.weight[0])[k])
+                + torch.matmul(Tx_2_i, (self.weight[1])[k])
+            )
+            Tx_0, Tx_1_o, Tx_1_i = Tx_1, Tx_2_o, Tx_2_i
+
+        if self.bias is not None:
+            H += self.bias
+       
+        return H
+
+
+class BatchedDCRNN(torch.nn.Module):
+
+    def __init__(self, in_channels: int, out_channels: int, K: int, bias: bool = True):
+        super(BatchedDCRNN, self).__init__()
+
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.K = K
+        self.bias = bias
+
+        self._create_parameters_and_layers()
+
+    def _create_update_gate_parameters_and_layers(self):
+        self.conv_x_z = BatchedDConv(
+            in_channels=self.in_channels + self.out_channels,
+            out_channels=self.out_channels,
+            K=self.K,
+            bias=self.bias,
+        )
+
+    def _create_reset_gate_parameters_and_layers(self):
+        self.conv_x_r = BatchedDConv(
+            in_channels=self.in_channels + self.out_channels,
+            out_channels=self.out_channels,
+            K=self.K,
+            bias=self.bias,
+        )
+
+    def _create_candidate_state_parameters_and_layers(self):
+        self.conv_x_h = BatchedDConv(
+            in_channels=self.in_channels + self.out_channels,
+            out_channels=self.out_channels,
+            K=self.K,
+            bias=self.bias,
+        )
+
+    def _create_parameters_and_layers(self):
+        self._create_update_gate_parameters_and_layers()
+        self._create_reset_gate_parameters_and_layers()
+        self._create_candidate_state_parameters_and_layers()
+
+    def _set_hidden_state(self, X, H):
+        if H is None:
+            H = torch.zeros(X.shape[0], self.out_channels).to(X.device)
+        return H
+
+    def _calculate_update_gate(self, X, edge_index, edge_weight, H):
+        
+        Z = torch.cat([X, H], dim=1)
+        Z = self.conv_x_z(Z, edge_index, edge_weight)
+        Z = torch.sigmoid(Z)
+        return Z
+
+    def _calculate_reset_gate(self, X, edge_index, edge_weight, H):
+        R = torch.cat([X, H], dim=1)
+        R = self.conv_x_r(R, edge_index, edge_weight)
+        R = torch.sigmoid(R)
+        return R
+
+    def _calculate_candidate_state(self, X, edge_index, edge_weight, H, R):
+        H_tilde = torch.cat([X, H * R], dim=1)
+        H_tilde = self.conv_x_h(H_tilde, edge_index, edge_weight)
+        H_tilde = torch.tanh(H_tilde)
+        return H_tilde
+
+    def _calculate_hidden_state(self, Z, H, H_tilde):
+        H = Z * H + (1 - Z) * H_tilde
+        return H
+
+    def forward(self, X, edge_index, edge_weight):
+        """
+        Forward pass for DCRNN with batching and sequence support.
+
+        Args:
+            X: Input tensor of shape (batch_size, seq_length, num_nodes, num_features)
+            edge_index: Edge index for the graph
+            edge_weight: Edge weights for the graph
+
+        Returns:
+            Output tensor of shape (batch_size, seq_length, num_nodes, out_channels)
+        """
+
+        
+        batch_size, seq_length, num_nodes, num_features = X.size()
+        hidden_state = torch.zeros(batch_size, num_nodes, self.out_channels).to(X.device)
+        
+        outputs = []
+        for t in range(seq_length):
+            x_t = X[:, t, :, :].reshape(batch_size * num_nodes, num_features)
+            
+            H = hidden_state.reshape(batch_size * num_nodes, self.out_channels)
+            Z = self._calculate_update_gate(x_t, edge_index, edge_weight, H)
+            R = self._calculate_reset_gate(x_t, edge_index, edge_weight, H)
+            H_tilde = self._calculate_candidate_state(x_t, edge_index, edge_weight, H, R)
+            H = self._calculate_hidden_state(Z, H, H_tilde)
+          
+            hidden_state = H.reshape(batch_size, num_nodes, self.out_channels)
+            outputs.append(hidden_state)
+
+        return torch.stack(outputs, dim=1)

--- a/torch_geometric_temporal/signal/__init__.py
+++ b/torch_geometric_temporal/signal/__init__.py
@@ -17,3 +17,5 @@ from .dynamic_hetero_graph_static_signal import *
 from .dynamic_hetero_graph_static_signal_batch import *
 
 from .train_test_split import *
+
+from .index_dataset import *

--- a/torch_geometric_temporal/signal/__init__.py
+++ b/torch_geometric_temporal/signal/__init__.py
@@ -18,4 +18,4 @@ from .dynamic_hetero_graph_static_signal_batch import *
 
 from .train_test_split import *
 
-from .index_dataset import *
+# from .index_dataset import *

--- a/torch_geometric_temporal/signal/index_dataset.py
+++ b/torch_geometric_temporal/signal/index_dataset.py
@@ -1,0 +1,57 @@
+import torch
+from torch.utils.data import Dataset
+import dask.array as da
+import numpy as np
+
+
+
+class IndexDataset(Dataset):
+    """
+    A custom PyTorch Dataset that implements indexBatching and lazyIndexBatching.
+    It also supports intergration with GPU indexPreprocessing and lazyPreprocessing.
+
+    Args:
+            indices (array-like): Indices corresponding to the time slicies.
+            data (array-like or Dask array): The dataset to be indexed.
+            horizon (int): The prediction period for the dataset.
+            lazy (bool, optional): Whether to use Dask lazy loading (distribute the data across all workers). Defaults to False.
+            gpu (bool, optional): If the data is already on the GPU. Defaults to False.
+    """
+    def __init__(self,indices, data, horizon, lazy=False, gpu=False):
+         self.indices = indices 
+         self.data = data
+         self.horizon = horizon
+         self.lazy = lazy
+         self.gpu = gpu
+        
+    def __len__(self):
+        # Return the number of samples
+        return self.indices.shape[0]
+
+    def __getitem__(self, x):
+        """
+        Retrieve a data sample and its corresponding target based on the index.
+
+        Args:
+            x (int): The index of the sample to retrieve.
+
+        Returns:
+            tuple: A tuple (x, y), where `x` is the input sequence and `y` is the target sequence.
+        """
+
+        idx = self.indices[x]
+        
+        # calcuate the offset based on the horizon value
+        y_start = idx + self.horizon
+
+        # if the data is already on the gpu (likely due to using index-gpu-preprocessing), return tensor-slice
+        if self.gpu:
+            return self.data[idx:y_start,...], self.data[y_start:y_start + self.horizon,...]
+        
+        else:
+            # if utilizing lazyBatching, gather the data on to this worker and convert to tensor
+            if self.lazy:
+                return torch.from_numpy(self.data[idx:y_start,...].compute()),torch.from_numpy(self.data[y_start:y_start + self.horizon,...].compute())
+            else:
+                return torch.from_numpy(self.data[idx:y_start,...]), torch.from_numpy(self.data[y_start:y_start + self.horizon,...])
+    

--- a/torch_geometric_temporal/signal/index_dataset.py
+++ b/torch_geometric_temporal/signal/index_dataset.py
@@ -7,8 +7,8 @@ import numpy as np
 
 class IndexDataset(Dataset):
     """
-    A custom PyTorch Dataset that implements indexBatching and lazyIndexBatching.
-    It also supports intergration with GPU indexPreprocessing and lazyPreprocessing.
+    A custom pytorch-compatible dataset that implements index-batching and DDP-index-batching.
+    It also supports GPU-index-batching and lazy-index-batching.
 
     Args:
             indices (array-like): Indices corresponding to the time slicies.
@@ -17,7 +17,7 @@ class IndexDataset(Dataset):
             lazy (bool, optional): Whether to use Dask lazy loading (distribute the data across all workers). Defaults to False.
             gpu (bool, optional): If the data is already on the GPU. Defaults to False.
     """
-    def __init__(self,indices, data, horizon, lazy=False, gpu=False):
+    def __init__(self, indices, data, horizon, lazy=False, gpu=False):
          self.indices = indices 
          self.data = data
          self.horizon = horizon
@@ -25,6 +25,7 @@ class IndexDataset(Dataset):
          self.gpu = gpu
         
     def __len__(self):
+
         # Return the number of samples
         return self.indices.shape[0]
 
@@ -41,15 +42,15 @@ class IndexDataset(Dataset):
 
         idx = self.indices[x]
         
-        # calcuate the offset based on the horizon value
+        # Calculate the offset based on the horizon value
         y_start = idx + self.horizon
 
-        # if the data is already on the gpu (likely due to using index-gpu-preprocessing), return tensor-slice
+        # If the data is already on the gpu (likely due to using index-gpu-preprocessing), return tensor-slice
         if self.gpu:
             return self.data[idx:y_start,...], self.data[y_start:y_start + self.horizon,...]
         
         else:
-            # if utilizing lazyBatching, gather the data on to this worker and convert to tensor
+            # if utilizing DDP-batching, gather the data on to this worker and convert to tensor
             if self.lazy:
                 return torch.from_numpy(self.data[idx:y_start,...].compute()),torch.from_numpy(self.data[y_start:y_start + self.horizon,...].compute())
             else:


### PR DESCRIPTION
This includes updates that introduce index-batching into PGT, add two additional datasets (PeMS and PeMSAllLA), and add a DDP-index-batching example. Single GPU examples for the following datasets are contained in the `/examples/indexBatching` folder and the bolded datasets also have DDP examples. The `examples/indexBatching` folder contains a readme that explains how to run each example and their command line parameters. 

* Chickenpox Hungary
* WindmillLarge
* **PemsBay**
* **PeMS**
* **PemsAllLA**