### PR TITLE
Documentation overhaul

### DIFF
--- a/docs/mapping.py
+++ b/docs/mapping.py
@@ -1,0 +1,125 @@
+import os
+import ast
+from collections import defaultdict
+
+def find_defined_classes_in_file(filepath):
+    with open(filepath, 'r', encoding='utf-8') as file:
+        try:
+            tree = ast.parse(file.read(), filename=filepath)
+        except SyntaxError:
+            return []
+
+    return [node.name for node in ast.walk(tree) if isinstance(node, ast.ClassDef)]
+
+def map_defined_classes(directories):
+    file_to_classes = defaultdict(list)
+    all_classes = set()
+    for directory in directories:
+        for root, _, files in os.walk(directory):
+            for file in files:
+                if file.endswith('.py'):
+                    full_path = os.path.join(root, file)
+                    class_names = find_defined_classes_in_file(full_path)
+                    if class_names:
+                        file_to_classes[full_path[3:].replace("/",".")].extend(class_names)
+                        all_classes.update(class_names)
+
+    return all_classes, file_to_classes
+
+if __name__ == "__main__":
+    # Replace these with the paths you want to analyze
+    directories_to_scan = [
+        "../torch_geometric_temporal/nn/recurrent",
+        "../torch_geometric_temporal/nn/attention",
+        "../torch_geometric_temporal/nn/hetero"
+    ]
+
+    all_classes, mapping = map_defined_classes(directories_to_scan)
+
+
+    order = [
+
+        "torch_geometric_temporal.nn.recurrent.gconv_gru",
+        "torch_geometric_temporal.nn.recurrent.gconv_lstm",
+        "torch_geometric_temporal.nn.recurrent.gc_lstm",
+        "torch_geometric_temporal.nn.recurrent.lrgcn",
+        "torch_geometric_temporal.nn.recurrent.dygrae",
+        "torch_geometric_temporal.nn.recurrent.evolvegcnh",
+        "torch_geometric_temporal.nn.recurrent.evolvegcno",
+        "torch_geometric_temporal.nn.recurrent.temporalgcn",
+        "torch_geometric_temporal.nn.recurrent.attentiontemporalgcn",
+        "torch_geometric_temporal.nn.recurrent.mpnn_lstm",
+        "torch_geometric_temporal.nn.recurrent.dcrnn",
+        "torch_geometric_temporal.nn.recurrent.agcrn",
+
+        "torch_geometric_temporal.nn.attention.stgcn", 
+        "torch_geometric_temporal.nn.attention.astgcn", 
+        "torch_geometric_temporal.nn.attention.mstgcn", 
+        "torch_geometric_temporal.nn.attention.gman", 
+        "torch_geometric_temporal.nn.attention.mtgnn", 
+        "torch_geometric_temporal.nn.attention.tsagcn", 
+        "torch_geometric_temporal.nn.attention.dnntsp", 
+
+        "torch_geometric_temporal.nn.hetero.heterogclstm"
+
+        ]
+    model = [
+        "GConvGRU",
+        "GConvLSTM",
+        "GCLSTM",
+        "LRGCN",
+        "DyGrEncoder",
+        "EvolveGCNH",
+        "EvolveGCNO",
+        "GCNConv_Fixed_W",
+        "TGCN",
+        "TGCN2",
+        "A3TGCN",
+        "A3TGCN2",
+        "MPNNLSTM",
+        "DCRNN",
+        "BatchedDCRNN",
+        "AGCRN",
+        "STConv",
+        "ASTGCN",
+        "MSTGCN",
+        "GMAN",
+        "SpatioTemporalAttention",
+        "GraphConstructor",
+        "MTGNN",
+        "AAGCN",
+        "DNNTSP"
+    ]
+    aux = [
+        "TemporalConv",
+        "DConv",
+        "BatchedDConv",
+        "ChebConvAttention",
+        "AVWGCN",
+        "UnitGCN",
+        "UnitTCN"
+    ]
+
+    het = [
+        "HeteroGCLSTM"
+    ]
+    # print(mapping.keys())
+    target = {}
+    for file, classes in mapping.items():
+
+
+        line = ""
+            
+        for c in all_classes:
+            if c not in classes:
+                line += f"{c}, "
+        
+        line = line[:-2]
+        target[file[:-3]] = line
+        
+
+    for key in order:
+        print(f".. autoapimodule:: {key}")
+        print("\t:members:")
+        print(f"\t:exclude-members: {target[key]}, LayerNormalization, AggregateTemporalNodeFeatures, GlobalGatedUpdater, MaskedSelfAttention, WeightedGCNBlock, LayerNormalization, K, bias, in_channels, out_channels, normalization, num_bases, num_relations, conv_aggr, conv_num_layers, conv_out_channels, lstm_num_layers, lstm_out_channels, add_self_loops, cached, improved, initial_weight, normalize, num_of_nodes, reinitialize_weight, reset_parameters, weight, batch_size, periods, dropout, hidden_size, num_nodes, window, number_of_nodes, bias_pool, weights_pool, hidden_channels, A, attention, edge_index, gcn1, graph, relu, tcn1, kernel_size, conv_1, conv_2, conv_3, nb_time_filter, adaptive, bn, conv_d, in_c, inter_c, num_jpts, num_subset, out_c, sigmoid, soft, tan, conv, embedding_dimensions, Wq, global_gated_updater, item_embedding, item_embedding_dim, items_total, masked_self_attention, stacked_gcn, in_channels_dict, meta")
+        print()

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
-https://download.pytorch.org/whl/cpu/torch-1.13.0%2Bcpu-cp39-cp39-linux_x86_64.whl
-numpy>=1.19.5
-git+https://github.com/pyg-team/pyg_sphinx_theme.git
-scipy
-networkx
+sphinx==7.0
+sphinx-rtd-theme
+sphinx-autoapi
+Jinja2>=3.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,7 +8,6 @@ import inspect
 
 
 extensions = [
-    # 'sphinx.ext.autodoc',
     'autoapi.extension',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
@@ -23,7 +22,6 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 autoapi_python_use_implicit_namespaces = False
-# autoapi_ignore = ["*temporal.signal*", "*temporal.nn*", "*temporal.datasets*"]
 
 author = 'Benedek Rozemberczki'
 project = 'PyTorch Geometric Temporal'
@@ -45,10 +43,10 @@ html_theme_options = {
 
 html_logo = '_static/img/text_logo.jpg'
 html_static_path = ['_static']
-# html_context = {'css_files': ['_static/css/custom.css']}
 
 add_module_names = False
 autoapi_generate_api_docs = False
+
 # --- AutoAPI config ---
 autoapi_type = 'python'
-autoapi_dirs = ['../../torch_geometric_temporal/']  # Adjust this to the relative path of your source code
+autoapi_dirs = ['../../torch_geometric_temporal/']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,27 +1,36 @@
 import datetime
 import sphinx_rtd_theme
 import doctest
-import torch_geometric_temporal
+import inspect
+
+
+
+
 
 extensions = [
-    'sphinx.ext.autodoc',
+    # 'sphinx.ext.autodoc',
+    'autoapi.extension',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
+    'sphinx_rtd_theme',
 ]
 
 source_suffix = '.rst'
 master_doc = 'index'
+
+autoapi_python_use_implicit_namespaces = False
+# autoapi_ignore = ["*temporal.signal*", "*temporal.nn*", "*temporal.datasets*"]
 
 author = 'Benedek Rozemberczki'
 project = 'PyTorch Geometric Temporal'
 copyright = '{}, {}'.format(datetime.datetime.now().year, author)
 
 html_theme = 'sphinx_rtd_theme'
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+autoapi_add_toctree_entry = True
 
 doctest_default_flags = doctest.NORMALIZE_WHITESPACE
 intersphinx_mapping = {'python': ('https://docs.python.org/', None)}
@@ -30,24 +39,16 @@ html_theme_options = {
     'collapse_navigation': False,
     'display_version': True,
     'logo_only': True,
+     'navigation_depth': 2,
 }
+
 
 html_logo = '_static/img/text_logo.jpg'
 html_static_path = ['_static']
-html_context = {'css_files': ['_static/css/custom.css']}
+# html_context = {'css_files': ['_static/css/custom.css']}
 
 add_module_names = False
-
-
-def setup(app):
-    def skip(app, what, name, obj, skip, options):
-        members = [
-            '__init__',
-            '__repr__',
-            '__weakref__',
-            '__dict__',
-            '__module__',
-        ]
-        return True if name in members else skip
-
-    app.connect('autodoc-skip-member', skip)
+autoapi_generate_api_docs = False
+# --- AutoAPI config ---
+autoapi_type = 'python'
+autoapi_dirs = ['../../torch_geometric_temporal/']  # Adjust this to the relative path of your source code

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,7 +29,7 @@ The package interfaces well with `Pytorch Lightning <https://pytorch-lightning.r
 
 .. toctree::
    :glob:
-   :maxdepth: 3
+   :maxdepth: 2
    :caption: Package Reference
 
    modules/root

--- a/docs/source/modules/dataset.rst
+++ b/docs/source/modules/dataset.rst
@@ -7,59 +7,73 @@ PyTorch Geometric Temporal Dataset
 Datasets
 -----------------------
 
-.. automodule:: torch_geometric_temporal.dataset.chickenpox
+.. autoapimodule:: torch_geometric_temporal.dataset.chickenpox
     :members:
     :undoc-members:
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal( 
     
-.. automodule:: torch_geometric_temporal.dataset.pedalme
+.. autoapimodule:: torch_geometric_temporal.dataset.pedalme
     :members:
     :undoc-members:
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
     
-.. automodule:: torch_geometric_temporal.dataset.wikimath
+.. autoapimodule:: torch_geometric_temporal.dataset.wikimath
     :members:
     :undoc-members:
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
     
-.. automodule:: torch_geometric_temporal.dataset.windmilllarge
+.. autoapimodule:: torch_geometric_temporal.dataset.windmilllarge
     :members:
     :undoc-members:
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
     
-.. automodule:: torch_geometric_temporal.dataset.windmillmedium
+.. autoapimodule:: torch_geometric_temporal.dataset.windmillmedium
     :members:
     :undoc-members:
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
         
-.. automodule:: torch_geometric_temporal.dataset.windmillsmall
+.. autoapimodule:: torch_geometric_temporal.dataset.windmillsmall
     :members:
     :undoc-members:
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
         
-.. automodule:: torch_geometric_temporal.dataset.metr_la
+.. autoapimodule:: torch_geometric_temporal.dataset.metr_la
     :members:
     :undoc-members:
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
     
-.. automodule:: torch_geometric_temporal.dataset.pems_bay
+.. autoapimodule:: torch_geometric_temporal.dataset.pems_bay
     :members:
     :undoc-members:
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
 
-.. automodule:: torch_geometric_temporal.dataset.pemsAllLA
+.. autoapimodule:: torch_geometric_temporal.dataset.pemsAllLA
     :members:
     :undoc-members:
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
 
-.. automodule:: torch_geometric_temporal.dataset.pems
+.. autoapimodule:: torch_geometric_temporal.dataset.pems
     :members:
     :undoc-members:
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
 
-.. automodule:: torch_geometric_temporal.dataset.encovid
+.. autoapimodule:: torch_geometric_temporal.dataset.encovid
     :members:
     :undoc-members:
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
 
-.. automodule:: torch_geometric_temporal.dataset.montevideo_bus
+.. autoapimodule:: torch_geometric_temporal.dataset.montevideo_bus
     :members:
     :undoc-members:
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
 
-.. automodule:: torch_geometric_temporal.dataset.twitter_tennis
+.. autoapimodule:: torch_geometric_temporal.dataset.twitter_tennis
     :members:
     :undoc-members:
-    :exclude-members: transform_degree, transform_transitivity, encode_features, onehot_encoding
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
+    :exclude-members:  transform_degree, transform_transitivity, encode_features, onehot_encoding
 
-.. automodule:: torch_geometric_temporal.dataset.mtm
+.. autoapimodule:: torch_geometric_temporal.dataset.mtm
     :members:
     :undoc-members:
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(

--- a/docs/source/modules/dataset.rst
+++ b/docs/source/modules/dataset.rst
@@ -10,70 +10,70 @@ Datasets
 .. autoapimodule:: torch_geometric_temporal.dataset.chickenpox
     :members:
     :undoc-members:
-    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal( 
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal 
     
 .. autoapimodule:: torch_geometric_temporal.dataset.pedalme
     :members:
     :undoc-members:
-    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal
     
 .. autoapimodule:: torch_geometric_temporal.dataset.wikimath
     :members:
     :undoc-members:
-    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal
     
 .. autoapimodule:: torch_geometric_temporal.dataset.windmilllarge
     :members:
     :undoc-members:
-    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal
     
 .. autoapimodule:: torch_geometric_temporal.dataset.windmillmedium
     :members:
     :undoc-members:
-    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal
         
 .. autoapimodule:: torch_geometric_temporal.dataset.windmillsmall
     :members:
     :undoc-members:
-    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal
         
 .. autoapimodule:: torch_geometric_temporal.dataset.metr_la
     :members:
     :undoc-members:
-    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal
     
 .. autoapimodule:: torch_geometric_temporal.dataset.pems_bay
     :members:
     :undoc-members:
-    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal
 
 .. autoapimodule:: torch_geometric_temporal.dataset.pemsAllLA
     :members:
     :undoc-members:
-    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal
 
 .. autoapimodule:: torch_geometric_temporal.dataset.pems
     :members:
     :undoc-members:
-    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal
 
 .. autoapimodule:: torch_geometric_temporal.dataset.encovid
     :members:
     :undoc-members:
-    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal
 
 .. autoapimodule:: torch_geometric_temporal.dataset.montevideo_bus
     :members:
     :undoc-members:
-    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal
 
 .. autoapimodule:: torch_geometric_temporal.dataset.twitter_tennis
     :members:
     :undoc-members:
-    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal
     :exclude-members:  transform_degree, transform_transitivity, encode_features, onehot_encoding
 
 .. autoapimodule:: torch_geometric_temporal.dataset.mtm
     :members:
     :undoc-members:
-    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal(
+    :exclude-members: index,additional_feature_keys,edge_index,edge_weight,features,targets, raw_data_dir, edge_indicies, edge_weights, StaticGraphTemporalSignal, DynamicGraphTemporalSignal

--- a/docs/source/modules/root.rst
+++ b/docs/source/modules/root.rst
@@ -4,131 +4,94 @@ PyTorch Geometric Temporal
 .. contents:: Contents
     :local:
 
+
+    .. :exclude-members: SpatialAttention, TemporalAttention, Conv2D, FullyConnected, Linear, GraphConstructor, DilatedInception, FullyConnected, Conv2D, LayerNormalization, AggregateTemporalNodeFeatures, GlobalGatedUpdater, MaskedSelfAttention, WeightedGCNBlock, K, bias, in_channels, out_channels, normalization, num_bases, num_relations, conv_aggr, conv_num_layers, conv_out_channels, lstm_num_layers, lstm_out_channels, add_self_loops, cached, improved, initial_weight, normalize, num_of_nodes, reinitialize_weight, reset_parameters, weight, batch_size, periods, dropout, hidden_size, num_nodes, window, number_of_nodes, bias_pool, weights_pool, hidden_channels, A, attention, edge_index, gcn1, graph, relu, tcn1, kernel_size, conv_1, conv_2, conv_3, nb_time_filter, adaptive, bn, conv_d, in_c, inter_c, num_jpts, num_subset, out_c, sigmoid, soft, tan, conv, embedding_dimensions, Wq, global_gated_updater, item_embedding, item_embedding_dim, items_total, masked_self_attention, stacked_gcn, in_channels_dict, meta   
 Recurrent Graph Convolutional Layers
 --------------
 
-.. automodule:: torch_geometric_temporal.nn.recurrent.gconv_gru
-    :members:
-    :undoc-members:
+.. autoapimodule:: torch_geometric_temporal.nn.recurrent.gconv_gru
+	:members:
+	:exclude-members: TemporalAttention, SpatialAttention, TemporalAttention, Conv2D, FullyConnected, Linear, GraphConstructor, DilatedInception, FullyConnected, Conv2D, LayerNormalization, AggregateTemporalNodeFeatures, GlobalGatedUpdater, MaskedSelfAttention, WeightedGCNBlock, DyGrEncoder, A3TGCN2, AVWGCN, TGCN2, BatchedDCRNN, GCLSTM, MPNNLSTM, EvolveGCNO, LRGCN, GConvLSTM, BatchedDConv, GCNConv_Fixed_W, DCRNN, AGCRN, EvolveGCNH, TGCN, DConv, A3TGCN, K, bias, in_channels, out_channels, normalization, num_bases, num_relations, conv_aggr, conv_num_layers, conv_out_channels, lstm_num_layers, lstm_out_channels, add_self_loops, cached, improved, initial_weight, normalize, num_of_nodes, reinitialize_weight, reset_parameters, weight, batch_size, periods, dropout, hidden_size, num_nodes, window, number_of_nodes, bias_pool, weights_pool, hidden_channels, A, attention, edge_index, gcn1, graph, relu, tcn1, kernel_size, conv_1, conv_2, conv_3, nb_time_filter, adaptive, bn, conv_d, in_c, inter_c, num_jpts, num_subset, out_c, sigmoid, soft, tan, conv, embedding_dimensions, Wq, global_gated_updater, item_embedding, item_embedding_dim, items_total, masked_self_attention, stacked_gcn, in_channels_dict, meta
 
-.. automodule:: torch_geometric_temporal.nn.recurrent.gconv_lstm
-    :members:
-    :undoc-members:
+.. autoapimodule:: torch_geometric_temporal.nn.recurrent.gconv_lstm
+	:members:
+	:exclude-members: SpatialAttention, TemporalAttention, Conv2D, FullyConnected, Linear, GraphConstructor, DilatedInception, FullyConnected, Conv2D, LayerNormalization, AggregateTemporalNodeFeatures, GlobalGatedUpdater, MaskedSelfAttention, WeightedGCNBlock, DyGrEncoder, A3TGCN2, AVWGCN, TGCN2, BatchedDCRNN, GCLSTM, MPNNLSTM, EvolveGCNO, LRGCN, GConvGRU, BatchedDConv, GCNConv_Fixed_W, DCRNN, AGCRN, EvolveGCNH, TGCN, DConv, A3TGCN, K, bias, in_channels, out_channels, normalization, num_bases, num_relations, conv_aggr, conv_num_layers, conv_out_channels, lstm_num_layers, lstm_out_channels, add_self_loops, cached, improved, initial_weight, normalize, num_of_nodes, reinitialize_weight, reset_parameters, weight, batch_size, periods, dropout, hidden_size, num_nodes, window, number_of_nodes, bias_pool, weights_pool, hidden_channels, A, attention, edge_index, gcn1, graph, relu, tcn1, kernel_size, conv_1, conv_2, conv_3, nb_time_filter, adaptive, bn, conv_d, in_c, inter_c, num_jpts, num_subset, out_c, sigmoid, soft, tan, conv, embedding_dimensions, Wq, global_gated_updater, item_embedding, item_embedding_dim, items_total, masked_self_attention, stacked_gcn, in_channels_dict, meta
 
-.. automodule:: torch_geometric_temporal.nn.recurrent.gc_lstm
-    :members:
-    :undoc-members:
+.. autoapimodule:: torch_geometric_temporal.nn.recurrent.gc_lstm
+	:members:
+	:exclude-members: SpatialAttention, TemporalAttention, Conv2D, FullyConnected, Linear, GraphConstructor, DilatedInception, FullyConnected, Conv2D, LayerNormalization, AggregateTemporalNodeFeatures, GlobalGatedUpdater, MaskedSelfAttention, WeightedGCNBlock, DyGrEncoder, A3TGCN2, AVWGCN, TGCN2, BatchedDCRNN, MPNNLSTM, EvolveGCNO, LRGCN, GConvLSTM, GConvGRU, BatchedDConv, GCNConv_Fixed_W, DCRNN, AGCRN, EvolveGCNH, TGCN, DConv, A3TGCN, K, bias, in_channels, out_channels, normalization, num_bases, num_relations, conv_aggr, conv_num_layers, conv_out_channels, lstm_num_layers, lstm_out_channels, add_self_loops, cached, improved, initial_weight, normalize, num_of_nodes, reinitialize_weight, reset_parameters, weight, batch_size, periods, dropout, hidden_size, num_nodes, window, number_of_nodes, bias_pool, weights_pool, hidden_channels, A, attention, edge_index, gcn1, graph, relu, tcn1, kernel_size, conv_1, conv_2, conv_3, nb_time_filter, adaptive, bn, conv_d, in_c, inter_c, num_jpts, num_subset, out_c, sigmoid, soft, tan, conv, embedding_dimensions, Wq, global_gated_updater, item_embedding, item_embedding_dim, items_total, masked_self_attention, stacked_gcn, in_channels_dict, meta
 
-.. automodule:: torch_geometric_temporal.nn.recurrent.lrgcn
-    :members:
-    :undoc-members:
+.. autoapimodule:: torch_geometric_temporal.nn.recurrent.lrgcn
+	:members:
+	:exclude-members: SpatialAttention, TemporalAttention, Conv2D, FullyConnected, Linear, GraphConstructor, DilatedInception, FullyConnected, Conv2D, LayerNormalization, AggregateTemporalNodeFeatures, GlobalGatedUpdater, MaskedSelfAttention, WeightedGCNBlock, DyGrEncoder, A3TGCN2, AVWGCN, TGCN2, BatchedDCRNN, GCLSTM, MPNNLSTM, EvolveGCNO, GConvLSTM, GConvGRU, BatchedDConv, GCNConv_Fixed_W, DCRNN, AGCRN, EvolveGCNH, TGCN, DConv, A3TGCN, K, bias, in_channels, out_channels, normalization, num_bases, num_relations, conv_aggr, conv_num_layers, conv_out_channels, lstm_num_layers, lstm_out_channels, add_self_loops, cached, improved, initial_weight, normalize, num_of_nodes, reinitialize_weight, reset_parameters, weight, batch_size, periods, dropout, hidden_size, num_nodes, window, number_of_nodes, bias_pool, weights_pool, hidden_channels, A, attention, edge_index, gcn1, graph, relu, tcn1, kernel_size, conv_1, conv_2, conv_3, nb_time_filter, adaptive, bn, conv_d, in_c, inter_c, num_jpts, num_subset, out_c, sigmoid, soft, tan, conv, embedding_dimensions, Wq, global_gated_updater, item_embedding, item_embedding_dim, items_total, masked_self_attention, stacked_gcn, in_channels_dict, meta
 
-.. automodule:: torch_geometric_temporal.nn.recurrent.dygrae
-    :members:
-    :undoc-members:
+.. autoapimodule:: torch_geometric_temporal.nn.recurrent.dygrae
+	:members:
+	:exclude-members: SpatialAttention, TemporalAttention, Conv2D, FullyConnected, Linear, GraphConstructor, DilatedInception, FullyConnected, Conv2D, LayerNormalization, AggregateTemporalNodeFeatures, GlobalGatedUpdater, MaskedSelfAttention, WeightedGCNBlock, A3TGCN2, AVWGCN, TGCN2, BatchedDCRNN, GCLSTM, MPNNLSTM, EvolveGCNO, LRGCN, GConvLSTM, GConvGRU, BatchedDConv, GCNConv_Fixed_W, DCRNN, AGCRN, EvolveGCNH, TGCN, DConv, A3TGCN, K, bias, in_channels, out_channels, normalization, num_bases, num_relations, conv_aggr, conv_num_layers, conv_out_channels, lstm_num_layers, lstm_out_channels, add_self_loops, cached, improved, initial_weight, normalize, num_of_nodes, reinitialize_weight, reset_parameters, weight, batch_size, periods, dropout, hidden_size, num_nodes, window, number_of_nodes, bias_pool, weights_pool, hidden_channels, A, attention, edge_index, gcn1, graph, relu, tcn1, kernel_size, conv_1, conv_2, conv_3, nb_time_filter, adaptive, bn, conv_d, in_c, inter_c, num_jpts, num_subset, out_c, sigmoid, soft, tan, conv, embedding_dimensions, Wq, global_gated_updater, item_embedding, item_embedding_dim, items_total, masked_self_attention, stacked_gcn, in_channels_dict, meta
 
-.. automodule:: torch_geometric_temporal.nn.recurrent.evolvegcnh
-    :members:
-    :undoc-members:
+.. autoapimodule:: torch_geometric_temporal.nn.recurrent.evolvegcnh
+	:members:
+	:exclude-members: SpatialAttention, TemporalAttention, Conv2D, FullyConnected, Linear, GraphConstructor, DilatedInception, FullyConnected, Conv2D, LayerNormalization, AggregateTemporalNodeFeatures, GlobalGatedUpdater, MaskedSelfAttention, WeightedGCNBlock, DyGrEncoder, A3TGCN2, AVWGCN, TGCN2, BatchedDCRNN, GCLSTM, MPNNLSTM, EvolveGCNO, LRGCN, GConvLSTM, GConvGRU, BatchedDConv, GCNConv_Fixed_W, DCRNN, AGCRN, TGCN, DConv, A3TGCN, K, bias, in_channels, out_channels, normalization, num_bases, num_relations, conv_aggr, conv_num_layers, conv_out_channels, lstm_num_layers, lstm_out_channels, add_self_loops, cached, improved, initial_weight, normalize, num_of_nodes, reinitialize_weight, reset_parameters, weight, batch_size, periods, dropout, hidden_size, num_nodes, window, number_of_nodes, bias_pool, weights_pool, hidden_channels, A, attention, edge_index, gcn1, graph, relu, tcn1, kernel_size, conv_1, conv_2, conv_3, nb_time_filter, adaptive, bn, conv_d, in_c, inter_c, num_jpts, num_subset, out_c, sigmoid, soft, tan, conv, embedding_dimensions, Wq, global_gated_updater, item_embedding, item_embedding_dim, items_total, masked_self_attention, stacked_gcn, in_channels_dict, meta
 
-.. automodule:: torch_geometric_temporal.nn.recurrent.evolvegcno
-    :members:
-    :undoc-members:
-    
-.. automodule:: torch_geometric_temporal.nn.recurrent.temporalgcn
-    :members:
-    :undoc-members:
-    
-.. automodule:: torch_geometric_temporal.nn.recurrent.attentiontemporalgcn
-    :members:
-    :undoc-members:
-    
-.. automodule:: torch_geometric_temporal.nn.recurrent.mpnn_lstm
-    :members:
-    :undoc-members:
+.. autoapimodule:: torch_geometric_temporal.nn.recurrent.evolvegcno
+	:members:
+	:exclude-members: SpatialAttention, TemporalAttention, Conv2D, FullyConnected, Linear, GraphConstructor, DilatedInception, FullyConnected, Conv2D, LayerNormalization, AggregateTemporalNodeFeatures, GlobalGatedUpdater, MaskedSelfAttention, WeightedGCNBlock, DyGrEncoder, A3TGCN2, AVWGCN, TGCN2, BatchedDCRNN, GCLSTM, MPNNLSTM, LRGCN, GConvLSTM, GConvGRU, BatchedDConv, DCRNN, AGCRN, EvolveGCNH, TGCN, DConv, A3TGCN, K, bias, in_channels, out_channels, normalization, num_bases, num_relations, conv_aggr, conv_num_layers, conv_out_channels, lstm_num_layers, lstm_out_channels, add_self_loops, cached, improved, initial_weight, normalize, num_of_nodes, reinitialize_weight, reset_parameters, weight, batch_size, periods, dropout, hidden_size, num_nodes, window, number_of_nodes, bias_pool, weights_pool, hidden_channels, A, attention, edge_index, gcn1, graph, relu, tcn1, kernel_size, conv_1, conv_2, conv_3, nb_time_filter, adaptive, bn, conv_d, in_c, inter_c, num_jpts, num_subset, out_c, sigmoid, soft, tan, conv, embedding_dimensions, Wq, global_gated_updater, item_embedding, item_embedding_dim, items_total, masked_self_attention, stacked_gcn, in_channels_dict, meta
 
-.. automodule:: torch_geometric_temporal.nn.recurrent.dcrnn
-    :members:
-    :undoc-members:
-    :exclude-members: DConv,BatchedDConv
+.. autoapimodule:: torch_geometric_temporal.nn.recurrent.temporalgcn
+	:members:
+	:exclude-members: SpatialAttention, TemporalAttention, Conv2D, FullyConnected, Linear, GraphConstructor, DilatedInception, FullyConnected, Conv2D, LayerNormalization, AggregateTemporalNodeFeatures, GlobalGatedUpdater, MaskedSelfAttention, WeightedGCNBlock, DyGrEncoder, A3TGCN2, AVWGCN, BatchedDCRNN, GCLSTM, MPNNLSTM, EvolveGCNO, LRGCN, GConvLSTM, GConvGRU, BatchedDConv, GCNConv_Fixed_W, DCRNN, AGCRN, EvolveGCNH, DConv, A3TGCN, K, bias, in_channels, out_channels, normalization, num_bases, num_relations, conv_aggr, conv_num_layers, conv_out_channels, lstm_num_layers, lstm_out_channels, add_self_loops, cached, improved, initial_weight, normalize, num_of_nodes, reinitialize_weight, reset_parameters, weight, batch_size, periods, dropout, hidden_size, num_nodes, window, number_of_nodes, bias_pool, weights_pool, hidden_channels, A, attention, edge_index, gcn1, graph, relu, tcn1, kernel_size, conv_1, conv_2, conv_3, nb_time_filter, adaptive, bn, conv_d, in_c, inter_c, num_jpts, num_subset, out_c, sigmoid, soft, tan, conv, embedding_dimensions, Wq, global_gated_updater, item_embedding, item_embedding_dim, items_total, masked_self_attention, stacked_gcn, in_channels_dict, meta
 
-.. automodule:: torch_geometric_temporal.nn.recurrent.agcrn
-    :members:
-    :undoc-members:
-    :exclude-members: AVWGCN
+.. autoapimodule:: torch_geometric_temporal.nn.recurrent.attentiontemporalgcn
+	:members:
+	:exclude-members: SpatialAttention, TemporalAttention, Conv2D, FullyConnected, Linear, GraphConstructor, DilatedInception, FullyConnected, Conv2D, LayerNormalization, AggregateTemporalNodeFeatures, GlobalGatedUpdater, MaskedSelfAttention, WeightedGCNBlock, DyGrEncoder, AVWGCN, TGCN2, BatchedDCRNN, GCLSTM, MPNNLSTM, EvolveGCNO, LRGCN, GConvLSTM, GConvGRU, BatchedDConv, GCNConv_Fixed_W, DCRNN, AGCRN, EvolveGCNH, TGCN, DConv, K, bias, in_channels, out_channels, normalization, num_bases, num_relations, conv_aggr, conv_num_layers, conv_out_channels, lstm_num_layers, lstm_out_channels, add_self_loops, cached, improved, initial_weight, normalize, num_of_nodes, reinitialize_weight, reset_parameters, weight, batch_size, periods, dropout, hidden_size, num_nodes, window, number_of_nodes, bias_pool, weights_pool, hidden_channels, A, attention, edge_index, gcn1, graph, relu, tcn1, kernel_size, conv_1, conv_2, conv_3, nb_time_filter, adaptive, bn, conv_d, in_c, inter_c, num_jpts, num_subset, out_c, sigmoid, soft, tan, conv, embedding_dimensions, Wq, global_gated_updater, item_embedding, item_embedding_dim, items_total, masked_self_attention, stacked_gcn, in_channels_dict, meta
+
+.. autoapimodule:: torch_geometric_temporal.nn.recurrent.mpnn_lstm
+	:members:
+	:exclude-members: SpatialAttention, TemporalAttention, Conv2D, FullyConnected, Linear, GraphConstructor, DilatedInception, FullyConnected, Conv2D, LayerNormalization, AggregateTemporalNodeFeatures, GlobalGatedUpdater, MaskedSelfAttention, WeightedGCNBlock, DyGrEncoder, A3TGCN2, AVWGCN, TGCN2, BatchedDCRNN, GCLSTM, EvolveGCNO, LRGCN, GConvLSTM, GConvGRU, BatchedDConv, GCNConv_Fixed_W, DCRNN, AGCRN, EvolveGCNH, TGCN, DConv, A3TGCN, K, bias, in_channels, out_channels, normalization, num_bases, num_relations, conv_aggr, conv_num_layers, conv_out_channels, lstm_num_layers, lstm_out_channels, add_self_loops, cached, improved, initial_weight, normalize, num_of_nodes, reinitialize_weight, reset_parameters, weight, batch_size, periods, dropout, hidden_size, num_nodes, window, number_of_nodes, bias_pool, weights_pool, hidden_channels, A, attention, edge_index, gcn1, graph, relu, tcn1, kernel_size, conv_1, conv_2, conv_3, nb_time_filter, adaptive, bn, conv_d, in_c, inter_c, num_jpts, num_subset, out_c, sigmoid, soft, tan, conv, embedding_dimensions, Wq, global_gated_updater, item_embedding, item_embedding_dim, items_total, masked_self_attention, stacked_gcn, in_channels_dict, meta
+
+.. autoapimodule:: torch_geometric_temporal.nn.recurrent.dcrnn
+	:members:
+	:exclude-members: SpatialAttention, TemporalAttention, Conv2D, FullyConnected, Linear, GraphConstructor, DilatedInception, FullyConnected, Conv2D, LayerNormalization, AggregateTemporalNodeFeatures, GlobalGatedUpdater, MaskedSelfAttention, WeightedGCNBlock, DyGrEncoder, A3TGCN2, AVWGCN, TGCN2, GCLSTM, MPNNLSTM, EvolveGCNO, LRGCN, GConvLSTM, GConvGRU, GCNConv_Fixed_W, AGCRN, EvolveGCNH, TGCN, A3TGCN, K, bias, in_channels, out_channels, normalization, num_bases, num_relations, conv_aggr, conv_num_layers, conv_out_channels, lstm_num_layers, lstm_out_channels, add_self_loops, cached, improved, initial_weight, normalize, num_of_nodes, reinitialize_weight, reset_parameters, weight, batch_size, periods, dropout, hidden_size, num_nodes, window, number_of_nodes, bias_pool, weights_pool, hidden_channels, A, attention, edge_index, gcn1, graph, relu, tcn1, kernel_size, conv_1, conv_2, conv_3, nb_time_filter, adaptive, bn, conv_d, in_c, inter_c, num_jpts, num_subset, out_c, sigmoid, soft, tan, conv, embedding_dimensions, Wq, global_gated_updater, item_embedding, item_embedding_dim, items_total, masked_self_attention, stacked_gcn, in_channels_dict, meta
+
+.. autoapimodule:: torch_geometric_temporal.nn.recurrent.agcrn
+	:members:
+	:exclude-members: SpatialAttention, TemporalAttention, Conv2D, FullyConnected, Linear, GraphConstructor, DilatedInception, FullyConnected, Conv2D, LayerNormalization, AggregateTemporalNodeFeatures, GlobalGatedUpdater, MaskedSelfAttention, WeightedGCNBlock, DyGrEncoder, A3TGCN2, TGCN2, BatchedDCRNN, GCLSTM, MPNNLSTM, EvolveGCNO, LRGCN, GConvLSTM, GConvGRU, BatchedDConv, GCNConv_Fixed_W, DCRNN, EvolveGCNH, TGCN, DConv, A3TGCN, K, bias, in_channels, out_channels, normalization, num_bases, num_relations, conv_aggr, conv_num_layers, conv_out_channels, lstm_num_layers, lstm_out_channels, add_self_loops, cached, improved, initial_weight, normalize, num_of_nodes, reinitialize_weight, reset_parameters, weight, batch_size, periods, dropout, hidden_size, num_nodes, window, number_of_nodes, bias_pool, weights_pool, hidden_channels, A, attention, edge_index, gcn1, graph, relu, tcn1, kernel_size, conv_1, conv_2, conv_3, nb_time_filter, adaptive, bn, conv_d, in_c, inter_c, num_jpts, num_subset, out_c, sigmoid, soft, tan, conv, embedding_dimensions, Wq, global_gated_updater, item_embedding, item_embedding_dim, items_total, masked_self_attention, stacked_gcn, in_channels_dict, meta
 
 Temporal Graph Attention Layers
 --------------
 
-.. automodule:: torch_geometric_temporal.nn.attention.stgcn
-    :members:
-    :undoc-members:
-    :exclude-members: TemporalConv
+.. autoapimodule:: torch_geometric_temporal.nn.attention.stgcn
+	:members:
+	:exclude-members: SpatialAttention, TemporalAttention, Conv2D, FullyConnected, Linear, GraphConstructor, DilatedInception, FullyConnected, Conv2D, LayerNormalization, AggregateTemporalNodeFeatures, GlobalGatedUpdater, MaskedSelfAttention, WeightedGCNBlock, GatedFusion, UnitTCN, UnitGCN, Linear, MTGNNLayer, MSTGCN, GraphConstructor, GMAN, DNNTSP, AggregateTemporalNodeFeatures, ASTGCN, TransformAttention, LayerNormalization, GraphAAGCN, SpatioTemporalEmbedding, MSTGCNBlock, Conv2D, AAGCN, MTGNN, MixProp, ASTGCNBlock, TemporalAttention, DilatedInception, SpatialAttention, MaskedSelfAttention, GlobalGatedUpdater, SpatioTemporalAttention, ChebConvAttention, FullyConnected, WeightedGCNBlock, K, bias, in_channels, out_channels, normalization, num_bases, num_relations, conv_aggr, conv_num_layers, conv_out_channels, lstm_num_layers, lstm_out_channels, add_self_loops, cached, improved, initial_weight, normalize, num_of_nodes, reinitialize_weight, reset_parameters, weight, batch_size, periods, dropout, hidden_size, num_nodes, window, number_of_nodes, bias_pool, weights_pool, hidden_channels, A, attention, edge_index, gcn1, graph, relu, tcn1, kernel_size, conv_1, conv_2, conv_3, nb_time_filter, adaptive, bn, conv_d, in_c, inter_c, num_jpts, num_subset, out_c, sigmoid, soft, tan, conv, embedding_dimensions, Wq, global_gated_updater, item_embedding, item_embedding_dim, items_total, masked_self_attention, stacked_gcn, in_channels_dict, meta
 
-.. automodule:: torch_geometric_temporal.nn.attention.astgcn
-    :members:
-    :undoc-members:
-    :exclude-members:  SpatialAttention, ASTGCNBlock, TemporalAttention, ChebConvAttention
-    
-.. automodule:: torch_geometric_temporal.nn.attention.mstgcn
-    :members:
-    :undoc-members:
-    :exclude-members: MSTGCNBlock
+.. autoapimodule:: torch_geometric_temporal.nn.attention.astgcn
+	:members:
+	:exclude-members: SpatialAttention, TemporalAttention, Conv2D, FullyConnected, Linear, GraphConstructor, DilatedInception, FullyConnected, Conv2D, LayerNormalization, AggregateTemporalNodeFeatures, GlobalGatedUpdater, MaskedSelfAttention, WeightedGCNBlock, GatedFusion, UnitTCN, UnitGCN, Linear, MTGNNLayer, MSTGCN, GraphConstructor, TemporalConv, GMAN, DNNTSP, AggregateTemporalNodeFeatures, TransformAttention, LayerNormalization, GraphAAGCN, SpatioTemporalEmbedding, MSTGCNBlock, Conv2D, AAGCN, MTGNN, MixProp, DilatedInception, MaskedSelfAttention, GlobalGatedUpdater, STConv, SpatioTemporalAttention, FullyConnected, WeightedGCNBlock, K, bias, in_channels, out_channels, normalization, num_bases, num_relations, conv_aggr, conv_num_layers, conv_out_channels, lstm_num_layers, lstm_out_channels, add_self_loops, cached, improved, initial_weight, normalize, num_of_nodes, reinitialize_weight, reset_parameters, weight, batch_size, periods, dropout, hidden_size, num_nodes, window, number_of_nodes, bias_pool, weights_pool, hidden_channels, A, attention, edge_index, gcn1, graph, relu, tcn1, kernel_size, conv_1, conv_2, conv_3, nb_time_filter, adaptive, bn, conv_d, in_c, inter_c, num_jpts, num_subset, out_c, sigmoid, soft, tan, conv, embedding_dimensions, Wq, global_gated_updater, item_embedding, item_embedding_dim, items_total, masked_self_attention, stacked_gcn, in_channels_dict, meta
 
-.. automodule:: torch_geometric_temporal.nn.attention.gman
-    :members:
-    :undoc-members:
-    :exclude-members: Conv2D, FullyConnected, SpatioTemporalEmbedding, SpatialAttention, TemporalAttention, GatedFusion, SpatioTemporalAttentionBlock, TransformAttention
-    
-.. automodule:: torch_geometric_temporal.nn.attention.mtgnn
-    :members:
-    :undoc-members:
-    :exclude-members: Linear, MixProp, DilatedInception, LayerNormalization, MTGNNLayer
+.. autoapimodule:: torch_geometric_temporal.nn.attention.mstgcn
+	:members:
+	:exclude-members: SpatialAttention, TemporalAttention, Conv2D, FullyConnected, Linear, GraphConstructor, DilatedInception, FullyConnected, Conv2D, LayerNormalization, AggregateTemporalNodeFeatures, GlobalGatedUpdater, MaskedSelfAttention, WeightedGCNBlock, GatedFusion, UnitTCN, UnitGCN, Linear, MTGNNLayer, GraphConstructor, TemporalConv, GMAN, DNNTSP, AggregateTemporalNodeFeatures, ASTGCN, TransformAttention, LayerNormalization, GraphAAGCN, SpatioTemporalEmbedding, Conv2D, AAGCN, MTGNN, MixProp, ASTGCNBlock, TemporalAttention, DilatedInception, SpatialAttention, MaskedSelfAttention, GlobalGatedUpdater, STConv, SpatioTemporalAttention, ChebConvAttention, FullyConnected, WeightedGCNBlock, K, bias, in_channels, out_channels, normalization, num_bases, num_relations, conv_aggr, conv_num_layers, conv_out_channels, lstm_num_layers, lstm_out_channels, add_self_loops, cached, improved, initial_weight, normalize, num_of_nodes, reinitialize_weight, reset_parameters, weight, batch_size, periods, dropout, hidden_size, num_nodes, window, number_of_nodes, bias_pool, weights_pool, hidden_channels, A, attention, edge_index, gcn1, graph, relu, tcn1, kernel_size, conv_1, conv_2, conv_3, nb_time_filter, adaptive, bn, conv_d, in_c, inter_c, num_jpts, num_subset, out_c, sigmoid, soft, tan, conv, embedding_dimensions, Wq, global_gated_updater, item_embedding, item_embedding_dim, items_total, masked_self_attention, stacked_gcn, in_channels_dict, meta
 
-.. automodule:: torch_geometric_temporal.nn.attention.tsagcn
-    :members:
-    :undoc-members:
-    :exclude-members: UnitGCN, UnitTCN, bn_init, conv_init, conv_branch_init, GraphAAGCN
-    
-    
-.. automodule:: torch_geometric_temporal.nn.attention.dnntsp
-    :members:
-    :undoc-members:
-    :exclude-members: WeightedGCNBlock, AggregateTemporalNodeFeatures, GlobalGatedUpdater, MaskedSelfAttention
+.. autoapimodule:: torch_geometric_temporal.nn.attention.gman
+	:members:
+	:exclude-members: SpatialAttention, TemporalAttention, Conv2D, FullyConnected, Linear, GraphConstructor, DilatedInception, FullyConnected, Conv2D, LayerNormalization, AggregateTemporalNodeFeatures, GlobalGatedUpdater, MaskedSelfAttention, WeightedGCNBlock, UnitTCN, UnitGCN, Linear, MTGNNLayer, MSTGCN, GraphConstructor, TemporalConv, DNNTSP, AggregateTemporalNodeFeatures, ASTGCN, LayerNormalization, GraphAAGCN, MSTGCNBlock, AAGCN, MTGNN, MixProp, ASTGCNBlock, DilatedInception, MaskedSelfAttention, GlobalGatedUpdater, STConv, ChebConvAttention, WeightedGCNBlock, K, bias, in_channels, out_channels, normalization, num_bases, num_relations, conv_aggr, conv_num_layers, conv_out_channels, lstm_num_layers, lstm_out_channels, add_self_loops, cached, improved, initial_weight, normalize, num_of_nodes, reinitialize_weight, reset_parameters, weight, batch_size, periods, dropout, hidden_size, num_nodes, window, number_of_nodes, bias_pool, weights_pool, hidden_channels, A, attention, edge_index, gcn1, graph, relu, tcn1, kernel_size, conv_1, conv_2, conv_3, nb_time_filter, adaptive, bn, conv_d, in_c, inter_c, num_jpts, num_subset, out_c, sigmoid, soft, tan, conv, embedding_dimensions, Wq, global_gated_updater, item_embedding, item_embedding_dim, items_total, masked_self_attention, stacked_gcn, in_channels_dict, meta
 
+.. autoapimodule:: torch_geometric_temporal.nn.attention.mtgnn
+	:members:
+	:exclude-members: SpatialAttention, TemporalAttention, Conv2D, FullyConnected, Linear, GraphConstructor, DilatedInception, FullyConnected, Conv2D, LayerNormalization, AggregateTemporalNodeFeatures, GlobalGatedUpdater, MaskedSelfAttention, WeightedGCNBlock, GatedFusion, UnitTCN, UnitGCN, MSTGCN, TemporalConv, GMAN, DNNTSP, AggregateTemporalNodeFeatures, ASTGCN, TransformAttention, GraphAAGCN, SpatioTemporalEmbedding, MSTGCNBlock, Conv2D, AAGCN, ASTGCNBlock, TemporalAttention, SpatialAttention, MaskedSelfAttention, GlobalGatedUpdater, STConv, SpatioTemporalAttention, ChebConvAttention, FullyConnected, WeightedGCNBlock, K, bias, in_channels, out_channels, normalization, num_bases, num_relations, conv_aggr, conv_num_layers, conv_out_channels, lstm_num_layers, lstm_out_channels, add_self_loops, cached, improved, initial_weight, normalize, num_of_nodes, reinitialize_weight, reset_parameters, weight, batch_size, periods, dropout, hidden_size, num_nodes, window, number_of_nodes, bias_pool, weights_pool, hidden_channels, A, attention, edge_index, gcn1, graph, relu, tcn1, kernel_size, conv_1, conv_2, conv_3, nb_time_filter, adaptive, bn, conv_d, in_c, inter_c, num_jpts, num_subset, out_c, sigmoid, soft, tan, conv, embedding_dimensions, Wq, global_gated_updater, item_embedding, item_embedding_dim, items_total, masked_self_attention, stacked_gcn, in_channels_dict, meta
 
-Auxiliary Graph Convolutional Layers
---------------
+.. autoapimodule:: torch_geometric_temporal.nn.attention.tsagcn
+	:members:
+	:exclude-members: SpatialAttention, TemporalAttention, Conv2D, FullyConnected, Linear, GraphConstructor, DilatedInception, FullyConnected, Conv2D, LayerNormalization, AggregateTemporalNodeFeatures, GlobalGatedUpdater, MaskedSelfAttention, WeightedGCNBlock, GatedFusion, Linear, MTGNNLayer, MSTGCN, GraphConstructor, TemporalConv, GMAN, DNNTSP, AggregateTemporalNodeFeatures, ASTGCN, TransformAttention, LayerNormalization, SpatioTemporalEmbedding, MSTGCNBlock, Conv2D, MTGNN, MixProp, ASTGCNBlock, TemporalAttention, DilatedInception, SpatialAttention, MaskedSelfAttention, GlobalGatedUpdater, STConv, SpatioTemporalAttention, ChebConvAttention, FullyConnected, WeightedGCNBlock, K, bias, in_channels, out_channels, normalization, num_bases, num_relations, conv_aggr, conv_num_layers, conv_out_channels, lstm_num_layers, lstm_out_channels, add_self_loops, cached, improved, initial_weight, normalize, num_of_nodes, reinitialize_weight, reset_parameters, weight, batch_size, periods, dropout, hidden_size, num_nodes, window, number_of_nodes, bias_pool, weights_pool, hidden_channels, A, attention, edge_index, gcn1, graph, relu, tcn1, kernel_size, conv_1, conv_2, conv_3, nb_time_filter, adaptive, bn, conv_d, in_c, inter_c, num_jpts, num_subset, out_c, sigmoid, soft, tan, conv, embedding_dimensions, Wq, global_gated_updater, item_embedding, item_embedding_dim, items_total, masked_self_attention, stacked_gcn, in_channels_dict, meta
 
-.. automodule:: torch_geometric_temporal.nn.attention.stgcn
-    :members:
-    :undoc-members:
-    :exclude-members: STConv
-
-.. automodule:: torch_geometric_temporal.nn.recurrent.dcrnn
-    :members:
-    :undoc-members:
-    :exclude-members: DCRNN, BatchedDCRNN
-
-.. automodule:: torch_geometric_temporal.nn.attention.astgcn
-    :members:
-    :undoc-members:
-    :exclude-members:  SpatialAttention, ASTGCNBlock, TemporalAttention, ASTGCN
-    
-.. automodule:: torch_geometric_temporal.nn.recurrent.agcrn
-    :members:
-    :undoc-members:
-    :exclude-members: AGCRN
-
-.. automodule:: torch_geometric_temporal.nn.attention.tsagcn
-    :members:
-    :undoc-members:
-    :exclude-members: bn_init, conv_init, conv_branch_init, GraphAAGCN, AAGCN
+.. autoapimodule:: torch_geometric_temporal.nn.attention.dnntsp
+	:members:
+	:exclude-members: SpatialAttention, TemporalAttention, Conv2D, FullyConnected, Linear, GraphConstructor, DilatedInception, FullyConnected, Conv2D, LayerNormalization, AggregateTemporalNodeFeatures, GlobalGatedUpdater, MaskedSelfAttention, WeightedGCNBlock, GatedFusion, UnitTCN, UnitGCN, Linear, MTGNNLayer, MSTGCN, GraphConstructor, TemporalConv, GMAN, ASTGCN, TransformAttention, LayerNormalization, GraphAAGCN, SpatioTemporalEmbedding, MSTGCNBlock, Conv2D, AAGCN, MTGNN, MixProp, ASTGCNBlock, TemporalAttention, DilatedInception, SpatialAttention, STConv, SpatioTemporalAttention, ChebConvAttention, FullyConnected, K, bias, in_channels, out_channels, normalization, num_bases, num_relations, conv_aggr, conv_num_layers, conv_out_channels, lstm_num_layers, lstm_out_channels, add_self_loops, cached, improved, initial_weight, normalize, num_of_nodes, reinitialize_weight, reset_parameters, weight, batch_size, periods, dropout, hidden_size, num_nodes, window, number_of_nodes, bias_pool, weights_pool, hidden_channels, A, attention, edge_index, gcn1, graph, relu, tcn1, kernel_size, conv_1, conv_2, conv_3, nb_time_filter, adaptive, bn, conv_d, in_c, inter_c, num_jpts, num_subset, out_c, sigmoid, soft, tan, conv, embedding_dimensions, Wq, global_gated_updater, item_embedding, item_embedding_dim, items_total, masked_self_attention, stacked_gcn, in_channels_dict, meta
 
 
 Heterogeneous Graph Convolutional Layers
 --------------
 
-.. automodule:: torch_geometric_temporal.nn.hetero.heterogclstm
-    :members:
-    :undoc-members:
+.. autoapimodule:: torch_geometric_temporal.nn.hetero.heterogclstm
+	:members:
+	:exclude-members: SpatialAttention, TemporalAttention, Conv2D, FullyConnected, Linear, GraphConstructor, DilatedInception, FullyConnected, Conv2D, LayerNormalization, AggregateTemporalNodeFeatures, GlobalGatedUpdater, MaskedSelfAttention, WeightedGCNBlock, , K, bias, in_channels, out_channels, normalization, num_bases, num_relations, conv_aggr, conv_num_layers, conv_out_channels, lstm_num_layers, lstm_out_channels, add_self_loops, cached, improved, initial_weight, normalize, num_of_nodes, reinitialize_weight, reset_parameters, weight, batch_size, periods, dropout, hidden_size, num_nodes, window, number_of_nodes, bias_pool, weights_pool, hidden_channels, A, attention, edge_index, gcn1, graph, relu, tcn1, kernel_size, conv_1, conv_2, conv_3, nb_time_filter, adaptive, bn, conv_d, in_c, inter_c, num_jpts, num_subset, out_c, sigmoid, soft, tan, conv, embedding_dimensions, Wq, global_gated_updater, item_embedding, item_embedding_dim, items_total, masked_self_attention, stacked_gcn, in_channels_dict, meta

--- a/docs/source/modules/root.rst
+++ b/docs/source/modules/root.rst
@@ -4,8 +4,6 @@ PyTorch Geometric Temporal
 .. contents:: Contents
     :local:
 
-
-    .. :exclude-members: SpatialAttention, TemporalAttention, Conv2D, FullyConnected, Linear, GraphConstructor, DilatedInception, FullyConnected, Conv2D, LayerNormalization, AggregateTemporalNodeFeatures, GlobalGatedUpdater, MaskedSelfAttention, WeightedGCNBlock, K, bias, in_channels, out_channels, normalization, num_bases, num_relations, conv_aggr, conv_num_layers, conv_out_channels, lstm_num_layers, lstm_out_channels, add_self_loops, cached, improved, initial_weight, normalize, num_of_nodes, reinitialize_weight, reset_parameters, weight, batch_size, periods, dropout, hidden_size, num_nodes, window, number_of_nodes, bias_pool, weights_pool, hidden_channels, A, attention, edge_index, gcn1, graph, relu, tcn1, kernel_size, conv_1, conv_2, conv_3, nb_time_filter, adaptive, bn, conv_d, in_c, inter_c, num_jpts, num_subset, out_c, sigmoid, soft, tan, conv, embedding_dimensions, Wq, global_gated_updater, item_embedding, item_embedding_dim, items_total, masked_self_attention, stacked_gcn, in_channels_dict, meta   
 Recurrent Graph Convolutional Layers
 --------------
 

--- a/docs/source/modules/signal.rst
+++ b/docs/source/modules/signal.rst
@@ -7,76 +7,91 @@ PyTorch Geometric Temporal Signal
 Temporal Signal Iterators
 -------------------------
 
-.. automodule:: torch_geometric_temporal.signal.static_graph_temporal_signal
+.. autoapimodule:: torch_geometric_temporal.signal.static_graph_temporal_signal
     :members:
     :undoc-members:
+    :exclude-members: Additional_Features, Edge_Index, Edge_Weight, Node_Features, features, targets, edge_weight, edge_index, additional_feature_keys, Targets, edge_indices, edge_weights, Edge_Indices, Edge_Weights, feature, Node_Feature, edge_index_dict, edge_weight_dict, feature_dicts, target_dicts, edge_index_dicts, edge_weight_dicts, feature_dict, Batches, batches, batch_dict, batch_dicts, data, gpu, horizon, indices, lazy
 
-.. automodule:: torch_geometric_temporal.signal.dynamic_graph_temporal_signal
-    :members:
-    :undoc-members:
 
-.. automodule:: torch_geometric_temporal.signal.dynamic_graph_static_signal
+.. autoapimodule:: torch_geometric_temporal.signal.dynamic_graph_temporal_signal
     :members:
     :undoc-members:
+    :exclude-members: Additional_Features, Edge_Index, Edge_Weight, Node_Features, features, targets, edge_weight, edge_index, additional_feature_keys, Targets, edge_indices, edge_weights, Edge_Indices, Edge_Weights, feature, Node_Feature, edge_index_dict, edge_weight_dict, feature_dicts, target_dicts, edge_index_dicts, edge_weight_dicts, feature_dict, Batches, batches, batch_dict, batch_dicts, data, gpu, horizon, indices, lazy
+
+.. autoapimodule:: torch_geometric_temporal.signal.dynamic_graph_static_signal
+    :members:
+    :undoc-members:
+    :exclude-members: Additional_Features, Edge_Index, Edge_Weight, Node_Features, features, targets, edge_weight, edge_index, additional_feature_keys, Targets, edge_indices, edge_weights, Edge_Indices, Edge_Weights, feature, Node_Feature, edge_index_dict, edge_weight_dict, feature_dicts, target_dicts, edge_index_dicts, edge_weight_dicts, feature_dict, Batches, batches, batch_dict, batch_dicts, data, gpu, horizon, indices, lazy
 
 Heterogeneous Temporal Signal Iterators
 -------------------------
 
-.. automodule:: torch_geometric_temporal.signal.static_hetero_graph_temporal_signal
+.. autoapimodule:: torch_geometric_temporal.signal.static_hetero_graph_temporal_signal
     :members:
     :undoc-members:
+    :exclude-members: Additional_Features, Edge_Index, Edge_Weight, Node_Features, features, targets, edge_weight, edge_index, additional_feature_keys, Targets, edge_indices, edge_weights, Edge_Indices, Edge_Weights, feature, Node_Feature, edge_index_dict, edge_weight_dict, feature_dicts, target_dicts, edge_index_dicts, edge_weight_dicts, feature_dict, Batches, batches, batch_dict, batch_dicts, data, gpu, horizon, indices, lazy
 
-.. automodule:: torch_geometric_temporal.signal.dynamic_hetero_graph_temporal_signal
+.. autoapimodule:: torch_geometric_temporal.signal.dynamic_hetero_graph_temporal_signal
     :members:
     :undoc-members:
+    :exclude-members: Additional_Features, Edge_Index, Edge_Weight, Node_Features, features, targets, edge_weight, edge_index, additional_feature_keys, Targets, edge_indices, edge_weights, Edge_Indices, Edge_Weights, feature, Node_Feature, edge_index_dict, edge_weight_dict, feature_dicts, target_dicts, edge_index_dicts, edge_weight_dicts, feature_dict, Batches, batches, batch_dict, batch_dicts, data, gpu, horizon, indices, lazy
 
-.. automodule:: torch_geometric_temporal.signal.dynamic_hetero_graph_static_signal
+.. autoapimodule:: torch_geometric_temporal.signal.dynamic_hetero_graph_static_signal
     :members:
     :undoc-members:
+    :exclude-members: Additional_Features, Edge_Index, Edge_Weight, Node_Features, features, targets, edge_weight, edge_index, additional_feature_keys, Targets, edge_indices, edge_weights, Edge_Indices, Edge_Weights, feature, Node_Feature, edge_index_dict, edge_weight_dict, feature_dicts, target_dicts, edge_index_dicts, edge_weight_dicts, feature_dict, Batches, batches, batch_dict, batch_dicts, data, gpu, horizon, indices, lazy
 
 Temporal Signal Batch Iterators
 -------------------------------
     
-.. automodule:: torch_geometric_temporal.signal.static_graph_temporal_signal_batch
+.. autoapimodule:: torch_geometric_temporal.signal.static_graph_temporal_signal_batch
     :members:
     :undoc-members:
+    :exclude-members: Additional_Features, Edge_Index, Edge_Weight, Node_Features, features, targets, edge_weight, edge_index, additional_feature_keys, Targets, edge_indices, edge_weights, Edge_Indices, Edge_Weights, feature, Node_Feature, edge_index_dict, edge_weight_dict, feature_dicts, target_dicts, edge_index_dicts, edge_weight_dicts, feature_dict, Batches, batches, batch_dict, batch_dicts, data, gpu, horizon, indices, lazy
 
-.. automodule:: torch_geometric_temporal.signal.dynamic_graph_temporal_signal_batch
+.. autoapimodule:: torch_geometric_temporal.signal.dynamic_graph_temporal_signal_batch
     :members:
     :undoc-members:
+    :exclude-members: Additional_Features, Edge_Index, Edge_Weight, Node_Features, features, targets, edge_weight, edge_index, additional_feature_keys, Targets, edge_indices, edge_weights, Edge_Indices, Edge_Weights, feature, Node_Feature, edge_index_dict, edge_weight_dict, feature_dicts, target_dicts, edge_index_dicts, edge_weight_dicts, feature_dict, Batches, batches, batch_dict, batch_dicts, data, gpu, horizon, indices, lazy
 
-.. automodule:: torch_geometric_temporal.signal.dynamic_graph_static_signal_batch
+.. autoapimodule:: torch_geometric_temporal.signal.dynamic_graph_static_signal_batch
     :members:
     :undoc-members:
+    :exclude-members: Additional_Features, Edge_Index, Edge_Weight, Node_Features, features, targets, edge_weight, edge_index, additional_feature_keys, Targets, edge_indices, edge_weights, Edge_Indices, Edge_Weights, feature, Node_Feature, edge_index_dict, edge_weight_dict, feature_dicts, target_dicts, edge_index_dicts, edge_weight_dicts, feature_dict, Batches, batches, batch_dict, batch_dicts, data, gpu, horizon, indices, lazy
 
 Heterogeneous Temporal Signal Batch Iterators
 -------------------------------
 
-.. automodule:: torch_geometric_temporal.signal.static_hetero_graph_temporal_signal_batch
+.. autoapimodule:: torch_geometric_temporal.signal.static_hetero_graph_temporal_signal_batch
     :members:
     :undoc-members:
+    :exclude-members: Additional_Features, Edge_Index, Edge_Weight, Node_Features, features, targets, edge_weight, edge_index, additional_feature_keys, Targets, edge_indices, edge_weights, Edge_Indices, Edge_Weights, feature, Node_Feature, edge_index_dict, edge_weight_dict, feature_dicts, target_dicts, edge_index_dicts, edge_weight_dicts, feature_dict, Batches, batches, batch_dict, batch_dicts, data, gpu, horizon, indices, lazy
 
-.. automodule:: torch_geometric_temporal.signal.dynamic_hetero_graph_temporal_signal_batch
+.. autoapimodule:: torch_geometric_temporal.signal.dynamic_hetero_graph_temporal_signal_batch
     :members:
     :undoc-members:
+    :exclude-members: Additional_Features, Edge_Index, Edge_Weight, Node_Features, features, targets, edge_weight, edge_index, additional_feature_keys, Targets, edge_indices, edge_weights, Edge_Indices, Edge_Weights, feature, Node_Feature, edge_index_dict, edge_weight_dict, feature_dicts, target_dicts, edge_index_dicts, edge_weight_dicts, feature_dict, Batches, batches, batch_dict, batch_dicts, data, gpu, horizon, indices, lazy
 
-.. automodule:: torch_geometric_temporal.signal.dynamic_hetero_graph_static_signal_batch
+.. autoapimodule:: torch_geometric_temporal.signal.dynamic_hetero_graph_static_signal_batch
     :members:
     :undoc-members:
+    :exclude-members: Additional_Features, Edge_Index, Edge_Weight, Node_Features, features, targets, edge_weight, edge_index, additional_feature_keys, Targets, edge_indices, edge_weights, Edge_Indices, Edge_Weights, feature, Node_Feature, edge_index_dict, edge_weight_dict, feature_dicts, target_dicts, edge_index_dicts, edge_weight_dicts, feature_dict, Batches, batches, batch_dict, batch_dicts, data, gpu, horizon, indices, lazy
 
 Temporal Signal Index-Batching Iterators
 --------------------------------
 
 
-.. automodule:: torch_geometric_temporal.signal.index_dataset
+.. autoapimodule:: torch_geometric_temporal.signal.index_dataset
     :members:
     :undoc-members:
+    :exclude-members: Additional_Features, Edge_Index, Edge_Weight, Node_Features, features, targets, edge_weight, edge_index, additional_feature_keys, Targets, edge_indices, edge_weights, Edge_Indices, Edge_Weights, feature, Node_Feature, edge_index_dict, edge_weight_dict, feature_dicts, target_dicts, edge_index_dicts, edge_weight_dicts, feature_dict, Batches, batches, batch_dict, batch_dicts, data, gpu, horizon, indices, lazy
 
 Temporal Signal Train-Test Split
 --------------------------------
-.. automodule:: torch_geometric_temporal.signal.temporal_signal_split
+.. autoapimodule:: torch_geometric_temporal.signal.temporal_signal_split
     :members:
     :undoc-members:
+    :exclude-members: Additional_Features, Edge_Index, Edge_Weight, Node_Features, features, targets, edge_weight, edge_index, additional_feature_keys, Targets, edge_indices, edge_weights, Edge_Indices, Edge_Weights, feature, Node_Feature, edge_index_dict, edge_weight_dict, feature_dicts, target_dicts, edge_index_dicts, edge_weight_dicts, feature_dict, Batches, batches, batch_dict, batch_dicts, data, gpu, horizon, indices, lazy
 
 
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,14 +1,13 @@
 version: 2
 
 build:
-   image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: docs/source/conf.py
 
 python:
-   version: 3.9
-   system_packages: true
-   install:
-      - requirements: docs/requirements.txt
-      - method: setuptools
-        path: .
-
-formats: []
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
Update docs to use autoapi instead of autodocs. This avoids needing to install dependencies to generate the doc files. A preview of the format can be found at https://pytorch-geometric-temporal.readthedocs.io/en/docsfix/ 