### PR TITLE
Remove torch-sparse and torch-scatter dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,8 +29,6 @@ jobs:
       - name: Install main dependencies
         run: |
          python -m pip install torch==2.3.0 torchvision torchaudio -f https://download.pytorch.org/whl/cpu/torch_stable.html
-         python -m pip install torch-sparse -f https://data.pyg.org/whl/torch-2.3.0+cpu.html
-         python -m pip install torch-scatter -f https://data.pyg.org/whl/torch-2.3.0+cpu.html
          python -m pip install torch-geometric
          python -m pip install sphinx sphinx_rtd_theme
       - name: Install main package

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ install_requires = [
     "numpy",
     "networkx",
 ]
-tests_require = ["pytest", "pytest-cov", "mock", "networkx", "tqdm",'dask', "pandas", "tables"]
+tests_require = ["pytest", "pytest-cov", "mock", "networkx", "tqdm",'dask', "pandas", "tables", "scipy"]
 index_require = ['dask', "pandas", "tables"]
 ddp_require = ["dask[distributed]", "dask_pytorch_ddp", "pandas", "tables"]
 

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,6 @@ install_requires = [
     "decorator==4.4.2",
     "torch",
     "cython",
-    "torch_sparse",
-    "torch_scatter",
     "torch_geometric",
     "numpy",
     "networkx",

--- a/torch_geometric_temporal/nn/recurrent/evolvegcno.py
+++ b/torch_geometric_temporal/nn/recurrent/evolvegcno.py
@@ -4,7 +4,7 @@ import torch
 from torch import Tensor
 from torch.nn import GRU
 from torch_geometric.typing import Adj, OptTensor
-from torch_sparse import SparseTensor
+from torch_geometric.typing import SparseTensor
 from torch_geometric.nn.inits import glorot
 from torch_geometric.nn.conv import MessagePassing
 from torch_geometric.nn.conv.gcn_conv import gcn_norm
@@ -142,7 +142,7 @@ class EvolveGCNO(torch.nn.Module):
         self.weight = None
         self._create_layers()
         self.reset_parameters()
-    
+
     def reset_parameters(self):
         glorot(self.initial_weight)
 
@@ -182,7 +182,7 @@ class EvolveGCNO(torch.nn.Module):
         Return types:
             * **X** *(PyTorch Float Tensor)* - Output matrix for all nodes.
         """
-        
+
         if self.weight is None:
             _, self.weight = self.recurrent_layer(self.initial_weight, self.initial_weight)
         else:


### PR DESCRIPTION
After PyG's [native implementation](https://github.com/pyg-team/pytorch_geometric/releases/tag/2.3.0), torch-sparse and torch-scatter aren't used anymore