### PR TITLE
Remove download path doubling in METR-LA

### DIFF
--- a/torch_geometric_temporal/dataset/metr_la.py
+++ b/torch_geometric_temporal/dataset/metr_la.py
@@ -37,11 +37,9 @@ class METRLADatasetLoader(object):
 
     def _download_url(self, url, save_path):  # pragma: no cover
         # Check if file is in data folder from working directory, otherwise download
-        if not os.path.isfile(
-        os.path.join(self.raw_data_dir,save_path)
-        ):
+        if not os.path.isfile(save_path):
             print("Downloading to", save_path, flush=True)
-            
+
             response = requests.get(url, stream=True)
             file_size = int(response.headers.get('content-length', 0))
 

--- a/torch_geometric_temporal/dataset/metr_la.py
+++ b/torch_geometric_temporal/dataset/metr_la.py
@@ -45,7 +45,7 @@ class METRLADatasetLoader(object):
             response = requests.get(url, stream=True)
             file_size = int(response.headers.get('content-length', 0))
 
-            with open(os.path.join(self.raw_data_dir, save_path), "wb") as file, tqdm(
+            with open(save_path, "wb") as file, tqdm(
                 total=file_size, unit="B", unit_scale=True, unit_divisor=1024
             ) as progress_bar:
                 for chunk in response.iter_content(chunk_size=33554432):


### PR DESCRIPTION
Fixes an issue in `METRLADatasetLoader` where downloading the dataset with `raw_data_dir="datasets/METR_LA"` results in an invalid duplicated file path (`datasets/METR_LA/datasets/METR_LA/METR-LA.zip`), causing a
`FileNotFoundError: [Errno 2] No such file or directory: 'datasets/METR_LA/datasets/METR_LA/METR-LA.zip'`.
